### PR TITLE
remove TZ=UTC from scripts>test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "tsc",
     "lint": "eslint ./src",
     "lint:fix": "eslint --fix ./src",
-    "test": "TZ=UTC jest ./src",
+    "test": "jest ./src",
     "release": "standard-version --tag-prefix --commit-all",
     "release:push": "git push --follow-tags"
   },

--- a/src/astronomicalObject/AstronomicalObject.test.js
+++ b/src/astronomicalObject/AstronomicalObject.test.js
@@ -1,7 +1,7 @@
 import {createTimeOfInterest} from '../time';
 import AstronomicalObject from './AstronomicalObject';
 
-jest.spyOn(global.Date, 'now').mockReturnValueOnce('2020-10-21 10:00:00');
+jest.spyOn(global.Date, 'now').mockReturnValueOnce('2020-10-21 10:00:00Z');
 
 class TestClass extends AstronomicalObject {
 }

--- a/src/time/createTimeOfInterest.test.js
+++ b/src/time/createTimeOfInterest.test.js
@@ -7,7 +7,7 @@ import createTimeOfInterest, {
     fromYearOfDay,
 } from './createTimeOfInterest';
 
-jest.spyOn(global.Date, 'now').mockReturnValue('2020-10-21 10:00:00');
+jest.spyOn(global.Date, 'now').mockReturnValue('2020-10-21 10:00:00Z');
 
 it('tests default export', () => {
     const toi = createTimeOfInterest();
@@ -28,7 +28,7 @@ it('tests fromTime', () => {
 });
 
 it('tests fromDate', () => {
-    const toi = fromDate(new Date('2016-07-08 12:34:56'));
+    const toi = fromDate(new Date('2016-07-08 12:34:56Z'));
 
     expect(toi.time).toEqual({year: 2016, month: 7, day: 8, hour: 12, min: 34, sec: 56});
 });


### PR DESCRIPTION
Issue: In windows system, when execute `npm test`, command `TZ=UTC` is not recognized.

May be we can 
1. remove `TZ=UTC` in test scripts from package.json.
2. change mock date string 
    * from '2016-07-08 12:34:56' to '2016-07-08 12:34:56Z' in createTimeOfInterest.test.js
    * from '2020-10-21 10:00:00' to '2020-10-21 10:00:00Z' in createTimeOfInterest.test.js
    * from '2020-10-21 10:00:00' to '2020-10-21 10:00:00Z' in astronomicalObject.test.js

so we can perform `npm test` on windows system also.

I think these changes will not make trouble in other operating systems and make test environment more robust.