### PR TITLE
modify getTimeOfInterestOfUpcomingPhase in moonPhaseCalc.ts

### DIFF
--- a/src/moon/Moon.test.js
+++ b/src/moon/Moon.test.js
@@ -275,19 +275,19 @@ it('tests getTopocentricApparentMagnitude', async () => {
 it('tests getUpcomingNewMoon', () => {
     const toiNewMoon = moon.getUpcomingNewMoon();
 
-    expect(toiNewMoon.time).toEqual({year: 1992, month: 4, day: 3, hour: 5, min: 2, sec: 3});
+    expect(toiNewMoon.time).toEqual({year: 1992, month: 5, day: 2, hour: 17, min: 44, sec: 56});
 });
 
 it('tests getUpcomingFirstQuarter', () => {
     const toiFirstQuarter = moon.getUpcomingFirstQuarter();
 
-    expect(toiFirstQuarter.time).toEqual({year: 1992, month: 4, day: 10, hour: 10, min: 6, sec: 42});
+    expect(toiFirstQuarter.time).toEqual({year: 1992, month: 5, day: 9, hour: 15, min: 44, sec: 22});
 });
 
 it('tests getUpcomingFullMoon', () => {
     const toiFullMoon = moon.getUpcomingFullMoon();
 
-    expect(toiFullMoon.time).toEqual({year: 1992, month: 4, day: 17, hour: 4, min: 43, sec: 22});
+    expect(toiFullMoon.time).toEqual({year: 1992, month: 4, day: 17, hour: 4, min: 43, sec: 21});
 });
 
 it('tests getUpcomingLastQuarter', () => {

--- a/src/utils/moonPhaseCalc.test.js
+++ b/src/utils/moonPhaseCalc.test.js
@@ -1,4 +1,5 @@
-import {MOON_PHASE_LAST_QUARTER, MOON_PHASE_NEW_MOON} from '../constants/moonPhase';
+import {MOON_PHASE_LAST_QUARTER, MOON_PHASE_NEW_MOON, MOON_PHASE_FIRST_QUARTER, MOON_PHASE_FULL_MOON}
+    from '../constants/moonPhase';
 import {getTimeOfInterestOfUpcomingPhase} from './moonPhaseCalc';
 
 it('tests getTimeOfInterestOfUpcomingPhase with new moon', () => {
@@ -11,4 +12,52 @@ it('tests getTimeOfInterestOfUpcomingPhase with last quarter', () => {
     const toi = getTimeOfInterestOfUpcomingPhase(2044, MOON_PHASE_LAST_QUARTER);
 
     expect(toi.time).toEqual({year: 2044, month: 1, day: 21, hour: 23, min: 48, sec: 15});
+});
+
+it('tests getTimeOfInterestOfUpcomingPhase with last quarter', () => {
+    // createTimeOfInterest.fromTime(2021, 3, 14, 0, 0, 0).getDecimalYear() = 2021.1972602739727
+    const toi = getTimeOfInterestOfUpcomingPhase(2021.1972602739727, MOON_PHASE_LAST_QUARTER);
+
+    expect(toi.time.year).toEqual(2021);
+    expect(toi.time.month).toEqual(4);
+    expect(toi.time.day).toEqual(4);
+    expect(toi.time.hour).toEqual(10);
+    expect(toi.time.min).toEqual(3);
+    expect(toi.time.sec).toEqual(49);
+});
+
+it('tests getTimeOfInterestOfUpcomingPhase with last quarter', () => {
+    // createTimeOfInterest.fromTime(2021, 3, 14, 0, 0, 0).getDecimalYear() = 2021.1972602739727
+    const toi = getTimeOfInterestOfUpcomingPhase(2021.1972602739727, MOON_PHASE_FIRST_QUARTER);
+
+    expect(toi.time.year).toEqual(2021);
+    expect(toi.time.month).toEqual(3);
+    expect(toi.time.day).toEqual(21);
+    expect(toi.time.hour).toEqual(14);
+    expect(toi.time.min).toEqual(41);
+    expect(toi.time.sec).toEqual(51);
+});
+
+it('tests getTimeOfInterestOfUpcomingPhase with last quarter', () => {
+    // createTimeOfInterest.fromTime(2021, 3, 14, 0, 0, 0).getDecimalYear() = 2021.1972602739727
+    const toi = getTimeOfInterestOfUpcomingPhase(2021.1972602739727, MOON_PHASE_FULL_MOON);
+
+    expect(toi.time.year).toEqual(2021);
+    expect(toi.time.month).toEqual(3);
+    expect(toi.time.day).toEqual(28);
+    expect(toi.time.hour).toEqual(18);
+    expect(toi.time.min).toEqual(49);
+    expect(toi.time.sec).toEqual(11);
+});
+
+it('tests getTimeOfInterestOfUpcomingPhase with last quarter', () => {
+    // createTimeOfInterest.fromTime(2021, 3, 14, 0, 0, 0).getDecimalYear() = 2021.1972602739727
+    const toi = getTimeOfInterestOfUpcomingPhase(2021.1972602739727, MOON_PHASE_NEW_MOON);
+
+    expect(toi.time.year).toEqual(2021);
+    expect(toi.time.month).toEqual(4);
+    expect(toi.time.day).toEqual(12);
+    expect(toi.time.hour).toEqual(2);
+    expect(toi.time.min).toEqual(32);
+    expect(toi.time.sec).toEqual(25);
 });


### PR DESCRIPTION
Issue #21 opend by swgordon : `getUpcomingLastQuarter skipping actual next date of last quarter moon phase`

Problem:
When I try to take above issue, I found below issue in Moon.test.js.

Given
```
const toi = createTimeOfInterest.fromTime(1992, 4, 12, 0, 0, 0);
const moon = createMoon(toi);
```
Want to test 
* moon.getUpcomingNewMoon() with {year: 1992, month: 4, day: 3, hour: 5, min: 2, sec: 3}
* moon.getUpcomingFirstQuarter() with {year: 1992, month: 4, day: 10, hour: 10, min: 6, sec: 42}

Obvisously date 1992/4/13 and 1992/4/10 are before 1992/4/12, contradict to "upcoming". 

I think it is a bug need to be fixed.

Solution:
1. Modify function getTimeOfInterestOfUpcomingPhase in moonPhaseCalc.ts to solve above problem.
2. Modify test data in Moon.test.js
3. Modify test data in moonPhaseCalc.test.js and add four new tests.
