### PR TITLE
Minor improvements + ideas for API changes

### DIFF
--- a/src/astronomicalObject/AstronomicalObject.test.js
+++ b/src/astronomicalObject/AstronomicalObject.test.js
@@ -4,6 +4,9 @@ import AstronomicalObject from './AstronomicalObject';
 jest.spyOn(global.Date, 'now').mockReturnValueOnce('2020-10-21 10:00:00Z');
 
 class TestClass extends AstronomicalObject {
+    constructor(toi) {
+        super('TestClass', toi);
+    }
 }
 
 it('creates an AstronomicalObject with TimeOfInterest', () => {
@@ -14,7 +17,7 @@ it('creates an AstronomicalObject with TimeOfInterest', () => {
     expect(astronomicalObject.toi.time).toEqual({year: 2000, month: 5, day: 10, min: 0, hour: 0, sec: 0});
 });
 
-it('creates an AstronomicalObject without TImeOfInterest', () => {
+it('creates an AstronomicalObject without TimeOfInterest', () => {
     const astronomicalObject = new TestClass();
 
     expect(astronomicalObject.toi.time).toEqual({year: 2020, month: 10, day: 21, hour: 10, min: 0, sec: 0});

--- a/src/earth/Earth.test.js
+++ b/src/earth/Earth.test.js
@@ -5,8 +5,8 @@ import Earth from './Earth';
 const toi = createTimeOfInterest.fromTime(2017, 12, 10, 0, 0, 0);
 const earth = new Earth(toi);
 
-it('tests getName', () => {
-    expect(earth.getName()).toBe('earth');
+it('get name should return expected value', () => {
+    expect(earth.name).toBe('earth');
 });
 
 it('test getHeliocentricEclipticRectangularJ2000Coordinates', async () => {

--- a/src/earth/Earth.ts
+++ b/src/earth/Earth.ts
@@ -1,13 +1,17 @@
 import AstronomicalObject from '../astronomicalObject/AstronomicalObject';
-import {earthCalc} from '../utils';
-import {EclipticSphericalCoordinates, RectangularCoordinates} from '../coordinates/coordinateTypes';
-import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {normalizeAngle} from '../utils/angleCalc';
-import {spherical2rectangular} from '../utils/coordinateCalc';
+import { getAsyncCachedCalculation } from '../cache/calculationCache';
+import { EclipticSphericalCoordinates, RectangularCoordinates } from '../coordinates/coordinateTypes';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { earthCalc } from '../utils';
+import { normalizeAngle } from '../utils/angleCalc';
+import { spherical2rectangular } from '../utils/coordinateCalc';
+import { calculateVSOP87, calculateVSOP87Angle } from '../utils/vsop87Calc';
 
 export default class Earth extends AstronomicalObject {
-    protected name = 'earth';
+
+    constructor(toi?: TimeOfInterest) {
+        super('earth', toi);
+    }
 
     public async getHeliocentricEclipticRectangularJ2000Coordinates(): Promise<RectangularCoordinates> {
         const coords = await this.getHeliocentricEclipticSphericalJ2000Coordinates();
@@ -46,23 +50,23 @@ export default class Earth extends AstronomicalObject {
     }
 
     getGeocentricEclipticRectangularJ2000Coordinates(): Promise<RectangularCoordinates> {
-        return Promise.reject({x: 0, y: 0, z: 0});
+        return Promise.reject({ x: 0, y: 0, z: 0 });
     }
 
     getGeocentricEclipticRectangularDateCoordinates(): Promise<RectangularCoordinates> {
-        return Promise.reject({x: 0, y: 0, z: 0});
+        return Promise.reject({ x: 0, y: 0, z: 0 });
     }
 
     getGeocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
-        return Promise.reject({lon: 0, lat: 0, radiusVector: 0});
+        return Promise.reject({ lon: 0, lat: 0, radiusVector: 0 });
     }
 
     getGeocentricEclipticSphericalDateCoordinates(): Promise<EclipticSphericalCoordinates> {
-        return Promise.reject({lon: 0, lat: 0, radiusVector: 0});
+        return Promise.reject({ lon: 0, lat: 0, radiusVector: 0 });
     }
 
     async getApparentGeocentricEclipticSphericalCoordinates(): Promise<EclipticSphericalCoordinates> {
-        return Promise.reject({lon: 0, lat: 0, radiusVector: 0});
+        return Promise.reject({ lon: 0, lat: 0, radiusVector: 0 });
     }
 
     public getNutationInLongitude() {

--- a/src/earth/Location.ts
+++ b/src/earth/Location.ts
@@ -1,9 +1,10 @@
-import {Location as LocationType} from './LocationTypes';
+import { Location as LocationType } from './LocationTypes';
 
 export default class Location {
-    private location: LocationType;
 
-    constructor(public lat: number, public lon: number, public elevation: number = 0) {
-        this.location = {lat, lon, elevation};
+    private readonly location: LocationType;
+
+    constructor(public readonly lat: number, public readonly lon: number, public readonly elevation: number = 0) {
+        this.location = { lat, lon, elevation };
     }
 }

--- a/src/moon/Moon.test.js
+++ b/src/moon/Moon.test.js
@@ -12,8 +12,8 @@ const location = {
     lon: -122.4108,
 };
 
-it('tests getName', () => {
-    expect(moon.getName()).toBe('moon');
+it('get name should return expected value', () => {
+    expect(moon.name).toBe('moon');
 });
 
 it('tests getHeliocentricEclipticRectangularJ2000Coordinates', async () => {

--- a/src/moon/Moon.ts
+++ b/src/moon/Moon.ts
@@ -1,38 +1,34 @@
-import {moonCalc, moonPhaseCalc, observationCalc} from '../utils';
 import AstronomicalObject from '../astronomicalObject/AstronomicalObject';
-import {EclipticSphericalCoordinates, RectangularCoordinates} from '../coordinates/coordinateTypes';
-import TimeOfInterest from '../time/TimeOfInterest';
+import { DIAMETER_MOON } from '../constants/diameters';
 import {
     MOON_PHASE_FIRST_QUARTER,
     MOON_PHASE_FULL_MOON,
     MOON_PHASE_LAST_QUARTER,
     MOON_PHASE_NEW_MOON
-} from '../constants/moonPhase';
-import {DIAMETER_MOON} from '../constants/diameters';
-import {getApparentMagnitudeMoon} from '../utils/magnitudeCalc';
-import {
-    rectangular2spherical,
-    rectangularGeocentric2rectangularHeliocentric,
-    spherical2rectangular
-} from '../utils/coordinateCalc';
-import {correctEffectOfNutation} from '../utils/apparentCoordinateCalc';
-import Sun from '../sun/Sun';
-import Earth from '../earth/Earth';
-import createSun from '../sun/createSun';
+    } from '../constants/moonPhase';
+import { STANDARD_ALTITUDE_MOON_CENTER_REFRACTION } from '../constants/standardAltitude';
+import { EclipticSphericalCoordinates, RectangularCoordinates } from '../coordinates/coordinateTypes';
 import createEarth from '../earth/createEarth';
-import {Location} from '../earth/LocationTypes';
-import {getRise, getSet, getTransit} from '../utils/riseSetTransitCalc';
-import {createTimeOfInterest} from '../time';
-import {STANDARD_ALTITUDE_MOON_CENTER_REFRACTION} from '../constants/standardAltitude';
+import Earth from '../earth/Earth';
+import { Location } from '../earth/LocationTypes';
+import createSun from '../sun/createSun';
+import Sun from '../sun/Sun';
+import { createTimeOfInterest } from '../time';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { moonCalc, moonPhaseCalc, observationCalc } from '../utils';
+import { correctEffectOfNutation } from '../utils/apparentCoordinateCalc';
+import { rectangular2spherical, rectangularGeocentric2rectangularHeliocentric, spherical2rectangular } from '../utils/coordinateCalc';
+import { getApparentMagnitudeMoon } from '../utils/magnitudeCalc';
+import { getRise, getSet, getTransit } from '../utils/riseSetTransitCalc';
 
 export default class Moon extends AstronomicalObject {
-    protected name = 'moon';
 
-    private sun: Sun;
-    private earth: Earth;
+    private readonly sun: Sun;
+
+    private readonly earth: Earth;
 
     constructor(toi?: TimeOfInterest) {
-        super(toi);
+        super('moon', toi);
 
         this.sun = createSun(toi);
         this.earth = createEarth(toi);
@@ -78,7 +74,7 @@ export default class Moon extends AstronomicalObject {
         const lat = moonCalc.getLatitude(this.T);
         const radiusVector = moonCalc.getRadiusVector(this.T);
 
-        return Promise.resolve({lon, lat, radiusVector});
+        return Promise.resolve({ lon, lat, radiusVector });
     }
 
     public async getApparentGeocentricEclipticSphericalCoordinates(): Promise<EclipticSphericalCoordinates> {

--- a/src/planets/Jupiter.test.js
+++ b/src/planets/Jupiter.test.js
@@ -13,8 +13,8 @@ const location = {
     lon: 13.408,
 };
 
-it('tests getName', () => {
-    expect(jupiter.getName()).toBe('jupiter');
+it('get name should return expected value', () => {
+    expect(jupiter.name).toBe('jupiter');
 });
 
 it('tests getHeliocentricEclipticRectangularJ2000Coordinates', async () => {

--- a/src/planets/Jupiter.ts
+++ b/src/planets/Jupiter.ts
@@ -1,14 +1,19 @@
 import Planet from './Planet';
-import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {observationCalc} from '../utils';
-import {DIAMETER_JUPITER} from '../constants/diameters';
-import {EclipticSphericalCoordinates} from '../coordinates/coordinateTypes';
-import {normalizeAngle} from '../utils/angleCalc';
-import {getApparentMagnitudeJupiter} from '../utils/magnitudeCalc';
+import { getAsyncCachedCalculation } from '../cache/calculationCache';
+import { DIAMETER_JUPITER } from '../constants/diameters';
+import { EclipticSphericalCoordinates } from '../coordinates/coordinateTypes';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { observationCalc } from '../utils';
+import { normalizeAngle } from '../utils/angleCalc';
+import { getApparentMagnitudeJupiter } from '../utils/magnitudeCalc';
+import { calculateVSOP87, calculateVSOP87Angle } from '../utils/vsop87Calc';
 
 export default class Jupiter extends Planet {
-    protected name = 'jupiter';
+
+
+    constructor(toi?: TimeOfInterest) {
+        super('jupiter', toi);
+    }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
         return await getAsyncCachedCalculation('jupiter_heliocentric_spherical_j2000', this.t, async () => {

--- a/src/planets/Mars.ts
+++ b/src/planets/Mars.ts
@@ -1,14 +1,19 @@
 import Planet from './Planet';
-import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {observationCalc} from '../utils';
-import {DIAMETER_MARS} from '../constants/diameters';
-import {EclipticSphericalCoordinates} from '../coordinates/coordinateTypes';
-import {normalizeAngle} from '../utils/angleCalc';
-import {getApparentMagnitudeMars} from '../utils/magnitudeCalc';
+import { getAsyncCachedCalculation } from '../cache/calculationCache';
+import { DIAMETER_MARS } from '../constants/diameters';
+import { EclipticSphericalCoordinates } from '../coordinates/coordinateTypes';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { observationCalc } from '../utils';
+import { normalizeAngle } from '../utils/angleCalc';
+import { getApparentMagnitudeMars } from '../utils/magnitudeCalc';
+import { calculateVSOP87, calculateVSOP87Angle } from '../utils/vsop87Calc';
 
 export default class Mars extends Planet {
-    protected name = 'mars';
+
+
+    constructor(toi?: TimeOfInterest) {
+        super('mars', toi);
+    }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
         return await getAsyncCachedCalculation('mars_heliocentric_spherical_j2000', this.t, async () => {

--- a/src/planets/Mercury.test.js
+++ b/src/planets/Mercury.test.js
@@ -13,8 +13,8 @@ const location = {
     lon: 13.408,
 };
 
-it('tests getName', () => {
-    expect(mercury.getName()).toBe('mercury');
+it('get name should return expected value', () => {
+    expect(mercury.name).toBe('mercury');
 });
 
 it('tests getHeliocentricEclipticRectangularJ2000Coordinates', async () => {

--- a/src/planets/Mercury.ts
+++ b/src/planets/Mercury.ts
@@ -1,14 +1,18 @@
 import Planet from './Planet';
-import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {observationCalc} from '../utils';
-import {DIAMETER_MERCURY} from '../constants/diameters';
-import {EclipticSphericalCoordinates} from '../coordinates/coordinateTypes';
-import {normalizeAngle} from '../utils/angleCalc';
-import {getApparentMagnitudeMercury} from '../utils/magnitudeCalc';
+import { getAsyncCachedCalculation } from '../cache/calculationCache';
+import { DIAMETER_MERCURY } from '../constants/diameters';
+import { EclipticSphericalCoordinates } from '../coordinates/coordinateTypes';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { observationCalc } from '../utils';
+import { normalizeAngle } from '../utils/angleCalc';
+import { getApparentMagnitudeMercury } from '../utils/magnitudeCalc';
+import { calculateVSOP87, calculateVSOP87Angle } from '../utils/vsop87Calc';
 
 export default class Mercury extends Planet {
-    protected name = 'mercury';
+
+    constructor(toi?: TimeOfInterest) {
+        super('mercury', toi);
+    }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
         return await getAsyncCachedCalculation('mercury_heliocentric_spherical_j2000', this.t, async () => {

--- a/src/planets/Neptune.ts
+++ b/src/planets/Neptune.ts
@@ -1,14 +1,19 @@
 import Planet from './Planet';
-import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {observationCalc} from '../utils';
-import {DIAMETER_NEPTUNE} from '../constants/diameters';
-import {EclipticSphericalCoordinates} from '../coordinates/coordinateTypes';
-import {normalizeAngle} from '../utils/angleCalc';
-import {getApparentMagnitudeNeptune} from '../utils/magnitudeCalc';
+import { getAsyncCachedCalculation } from '../cache/calculationCache';
+import { DIAMETER_NEPTUNE } from '../constants/diameters';
+import { EclipticSphericalCoordinates } from '../coordinates/coordinateTypes';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { observationCalc } from '../utils';
+import { normalizeAngle } from '../utils/angleCalc';
+import { getApparentMagnitudeNeptune } from '../utils/magnitudeCalc';
+import { calculateVSOP87, calculateVSOP87Angle } from '../utils/vsop87Calc';
 
 export default class Neptune extends Planet {
-    protected name = 'neptune';
+
+
+    constructor(toi?: TimeOfInterest) {
+        super('neptune', toi);
+    }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
         return await getAsyncCachedCalculation('neptune_heliocentric_spherical_j2000', this.t, async () => {

--- a/src/planets/Planet.ts
+++ b/src/planets/Planet.ts
@@ -1,41 +1,35 @@
-import {
-    rectangular2spherical,
-    rectangularHeliocentric2rectangularGeocentric,
-    spherical2rectangular
-} from '../utils/coordinateCalc';
-import AstronomicalObject from '../astronomicalObject/AstronomicalObject';
-import {RectangularCoordinates} from '../coordinates/coordinateTypes';
-import {EclipticSphericalCoordinates} from '../coordinates/coordinateTypes';
 import IPlanet from './interfaces/IPlanet';
-import {observationCalc} from '../utils';
-import {createSun} from '../sun';
-import TimeOfInterest from '../time/TimeOfInterest';
-import {createEarth} from '../earth';
-import Earth from '../earth/Earth';
-import Sun from '../sun/Sun';
-import {
-    correctEffectOfAberration,
-    correctEffectOfNutation,
-    getLightTimeCorrectedJulianDay
-} from '../utils/apparentCoordinateCalc';
-import {createTimeOfInterest} from '../time';
-import {getRise, getSet, getTransit} from '../utils/riseSetTransitCalc';
-import {Location} from '../earth/LocationTypes';
-import {STANDARD_ALTITUDE_PLANET_REFRACTION} from '../constants/standardAltitude';
-import Mercury from './Mercury';
-import Venus from './Venus';
-import Mars from './Mars';
 import Jupiter from './Jupiter';
+import Mars from './Mars';
+import Mercury from './Mercury';
+import Neptune from './Neptune';
 import Saturn from './Saturn';
 import Uranus from './Uranus';
-import Neptune from './Neptune';
+import Venus from './Venus';
+import AstronomicalObject from '../astronomicalObject/AstronomicalObject';
+import { STANDARD_ALTITUDE_PLANET_REFRACTION } from '../constants/standardAltitude';
+import { RectangularCoordinates } from '../coordinates/coordinateTypes';
+import { EclipticSphericalCoordinates } from '../coordinates/coordinateTypes';
+import { createEarth } from '../earth';
+import Earth from '../earth/Earth';
+import { Location } from '../earth/LocationTypes';
+import { createSun } from '../sun';
+import Sun from '../sun/Sun';
+import { createTimeOfInterest } from '../time';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { observationCalc } from '../utils';
+import { correctEffectOfAberration, correctEffectOfNutation, getLightTimeCorrectedJulianDay } from '../utils/apparentCoordinateCalc';
+import { rectangular2spherical, rectangularHeliocentric2rectangularGeocentric, spherical2rectangular } from '../utils/coordinateCalc';
+import { getRise, getSet, getTransit } from '../utils/riseSetTransitCalc';
 
 export default abstract class Planet extends AstronomicalObject implements IPlanet {
-    private sun: Sun;
-    private earth: Earth;
 
-    constructor(toi?: TimeOfInterest, protected useVsop87Short: boolean = false) {
-        super(toi);
+    private readonly sun: Sun;
+
+    private readonly earth: Earth;
+
+    constructor(name: string, toi?: TimeOfInterest, protected useVsop87Short: boolean = false) {
+        super(name, toi);
 
         this.sun = createSun(toi);
         this.earth = createEarth(toi);
@@ -144,7 +138,7 @@ export default abstract class Planet extends AstronomicalObject implements IPlan
     }
 
     private async getLightTimeCorrectedEclipticSphericalCoordinates(): Promise<EclipticSphericalCoordinates> {
-        const {radiusVector} = await this.getGeocentricEclipticSphericalDateCoordinates();
+        const { radiusVector } = await this.getGeocentricEclipticSphericalDateCoordinates();
 
         const jd = getLightTimeCorrectedJulianDay(this.jd, radiusVector);
         const toi = createTimeOfInterest.fromJulianDay(jd);

--- a/src/planets/Saturn.ts
+++ b/src/planets/Saturn.ts
@@ -1,14 +1,18 @@
 import Planet from './Planet';
-import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {observationCalc} from '../utils';
-import {DIAMETER_SATURN} from '../constants/diameters';
-import {EclipticSphericalCoordinates} from '../coordinates/coordinateTypes';
-import {normalizeAngle} from '../utils/angleCalc';
-import {getApparentMagnitudeSaturn} from '../utils/magnitudeCalc';
+import { getAsyncCachedCalculation } from '../cache/calculationCache';
+import { DIAMETER_SATURN } from '../constants/diameters';
+import { EclipticSphericalCoordinates } from '../coordinates/coordinateTypes';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { observationCalc } from '../utils';
+import { normalizeAngle } from '../utils/angleCalc';
+import { getApparentMagnitudeSaturn } from '../utils/magnitudeCalc';
+import { calculateVSOP87, calculateVSOP87Angle } from '../utils/vsop87Calc';
 
 export default class Saturn extends Planet {
-    protected name = 'saturn';
+
+    constructor(toi?: TimeOfInterest) {
+        super('saturn', toi);
+    }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
         return await getAsyncCachedCalculation('saturn_heliocentric_spherical_j2000', this.t, async () => {

--- a/src/planets/Uranus.ts
+++ b/src/planets/Uranus.ts
@@ -1,14 +1,19 @@
 import Planet from './Planet';
-import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {observationCalc} from '../utils';
-import {DIAMETER_URANUS} from '../constants/diameters';
-import {EclipticSphericalCoordinates} from '../coordinates/coordinateTypes';
-import {normalizeAngle} from '../utils/angleCalc';
-import {getApparentMagnitudeUranus} from '../utils/magnitudeCalc';
+import { getAsyncCachedCalculation } from '../cache/calculationCache';
+import { DIAMETER_URANUS } from '../constants/diameters';
+import { EclipticSphericalCoordinates } from '../coordinates/coordinateTypes';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { observationCalc } from '../utils';
+import { normalizeAngle } from '../utils/angleCalc';
+import { getApparentMagnitudeUranus } from '../utils/magnitudeCalc';
+import { calculateVSOP87, calculateVSOP87Angle } from '../utils/vsop87Calc';
 
 export default class Uranus extends Planet {
-    protected name = 'uranus';
+
+
+    constructor(toi?: TimeOfInterest) {
+        super('uranus', toi);
+    }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
         return await getAsyncCachedCalculation('uranus_heliocentric_spherical_j2000', this.t, async () => {

--- a/src/planets/Venus.test.js
+++ b/src/planets/Venus.test.js
@@ -13,8 +13,8 @@ const location = {
     lon: 13.408,
 };
 
-it('tests getName', () => {
-    expect(venus.getName()).toBe('venus');
+it('get name should return expected value', () => {
+    expect(venus.name).toBe('venus');
 });
 
 it('tests getHeliocentricEclipticRectangularJ2000Coordinates', async () => {

--- a/src/planets/Venus.ts
+++ b/src/planets/Venus.ts
@@ -1,14 +1,19 @@
 import Planet from './Planet';
-import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {observationCalc} from '../utils';
-import {DIAMETER_VENUS} from '../constants/diameters';
-import {normalizeAngle} from '../utils/angleCalc';
-import {EclipticSphericalCoordinates} from '../coordinates/coordinateTypes';
-import {getApparentMagnitudeVenus} from '../utils/magnitudeCalc';
+import { getAsyncCachedCalculation } from '../cache/calculationCache';
+import { DIAMETER_VENUS } from '../constants/diameters';
+import { EclipticSphericalCoordinates } from '../coordinates/coordinateTypes';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { observationCalc } from '../utils';
+import { normalizeAngle } from '../utils/angleCalc';
+import { getApparentMagnitudeVenus } from '../utils/magnitudeCalc';
+import { calculateVSOP87, calculateVSOP87Angle } from '../utils/vsop87Calc';
 
 export default class Venus extends Planet {
-    protected name = 'venus';
+
+
+    constructor(toi?: TimeOfInterest) {
+        super('venus', toi);
+    }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
         return await getAsyncCachedCalculation('venus_heliocentric_spherical_j2000', this.t, async () => {

--- a/src/planets/createPlanet.ts
+++ b/src/planets/createPlanet.ts
@@ -1,11 +1,11 @@
-import TimeOfInterest from '../time/TimeOfInterest';
-import Mercury from './Mercury';
-import Venus from './Venus';
-import Mars from './Mars';
 import Jupiter from './Jupiter';
+import Mars from './Mars';
+import Mercury from './Mercury';
+import Neptune from './Neptune';
 import Saturn from './Saturn';
 import Uranus from './Uranus';
-import Neptune from './Neptune';
+import Venus from './Venus';
+import TimeOfInterest from '../time/TimeOfInterest';
 
 export function createMercury(toi?: TimeOfInterest): Mercury {
     return new Mercury(toi);

--- a/src/stars/Star.ts
+++ b/src/stars/Star.ts
@@ -1,29 +1,22 @@
+import { ProperMotion } from './starTypes';
 import AstronomicalObject from '../astronomicalObject/AstronomicalObject';
-import {
-    EclipticSphericalCoordinates,
-    EquatorialSphericalCoordinates,
-    RectangularCoordinates
-} from '../coordinates/coordinateTypes';
+import { EPOCH_J2000 } from '../constants/epoch';
+import { EclipticSphericalCoordinates, EquatorialSphericalCoordinates, RectangularCoordinates } from '../coordinates/coordinateTypes';
 import TimeOfInterest from '../time/TimeOfInterest';
-import {EPOCH_J2000} from '../constants/epoch';
-import {
-    eclipticSpherical2equatorialSpherical,
-    equatorialSpherical2eclipticSpherical,
-    spherical2rectangular
-} from '../utils/coordinateCalc';
-import {correctProperMotion} from '../utils/starCalc';
-import {correctPrecessionForEquatorialCoordinates} from '../utils/precessionCalc';
-import {correctEffectOfAberration, correctEffectOfNutation} from '../utils/apparentCoordinateCalc';
-import {ProperMotion} from './starTypes';
+import { correctEffectOfAberration, correctEffectOfNutation } from '../utils/apparentCoordinateCalc';
+import { eclipticSpherical2equatorialSpherical, equatorialSpherical2eclipticSpherical, spherical2rectangular } from '../utils/coordinateCalc';
+import { correctPrecessionForEquatorialCoordinates } from '../utils/precessionCalc';
+import { correctProperMotion } from '../utils/starCalc';
 
 export default class Star extends AstronomicalObject {
-    public constructor(
-        private equatorialCoords: EquatorialSphericalCoordinates,
+
+    constructor(
+        private readonly equatorialCoords: EquatorialSphericalCoordinates,
         toi?: TimeOfInterest,
-        private properMotion: ProperMotion = {rightAscension: 0, declination: 0},
-        private referenceEpoch: number = EPOCH_J2000,
+        private readonly properMotion: ProperMotion = { rightAscension: 0, declination: 0 },
+        private readonly referenceEpoch: number = EPOCH_J2000,
     ) {
-        super(toi);
+        super('star', toi);
     }
 
     async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {

--- a/src/sun/Sun.test.js
+++ b/src/sun/Sun.test.js
@@ -12,8 +12,8 @@ const location = {
     lon: 13.408,
 };
 
-it('tests getName', () => {
-    expect(sun.getName()).toBe('sun');
+it('get name should return expected value', () => {
+    expect(sun.name).toBe('sun');
 });
 
 it('tests getGeocentricEclipticRectangularJ2000Coordinates', async () => {

--- a/src/sun/Sun.ts
+++ b/src/sun/Sun.ts
@@ -1,45 +1,41 @@
-import {observationCalc} from '../utils';
 import AstronomicalObject from '../astronomicalObject/AstronomicalObject';
-import {EclipticSphericalCoordinates, RectangularCoordinates} from '../coordinates/coordinateTypes';
-import {DIAMETER_SUN} from '../constants/diameters';
-import {earthEclipticSpherical2sunEclipticSpherical, spherical2rectangular} from '../utils/coordinateCalc';
-import TimeOfInterest from '../time/TimeOfInterest';
+import { DIAMETER_SUN } from '../constants/diameters';
+import { STANDARD_ALTITUDE_SUN_CENTER_REFRACTION, STANDARD_ALTITUDE_SUN_UPPER_LIMB_REFRACTION } from '../constants/standardAltitude';
+import { EclipticSphericalCoordinates, RectangularCoordinates } from '../coordinates/coordinateTypes';
+import { createEarth } from '../earth';
 import Earth from '../earth/Earth';
-import {createEarth} from '../earth';
-import {correctEffectOfAberration, correctEffectOfNutation} from '../utils/apparentCoordinateCalc';
-import {Location} from '../earth/LocationTypes';
-import {createTimeOfInterest} from '../time';
-import {getRise, getSet, getTransit} from '../utils/riseSetTransitCalc';
-import {
-    STANDARD_ALTITUDE_SUN_CENTER_REFRACTION,
-    STANDARD_ALTITUDE_SUN_UPPER_LIMB_REFRACTION
-} from '../constants/standardAltitude';
+import { Location } from '../earth/LocationTypes';
+import { createTimeOfInterest } from '../time';
+import TimeOfInterest from '../time/TimeOfInterest';
+import { observationCalc } from '../utils';
+import { correctEffectOfAberration, correctEffectOfNutation } from '../utils/apparentCoordinateCalc';
+import { earthEclipticSpherical2sunEclipticSpherical, spherical2rectangular } from '../utils/coordinateCalc';
+import { getRise, getSet, getTransit } from '../utils/riseSetTransitCalc';
 
 export default class Sun extends AstronomicalObject {
-    protected name = 'sun';
 
-    private earth: Earth;
+    private readonly earth: Earth;
 
     constructor(toi?: TimeOfInterest) {
-        super(toi);
+        super('sun', toi);
 
         this.earth = createEarth(toi);
     }
 
     public async getHeliocentricEclipticRectangularJ2000Coordinates(): Promise<RectangularCoordinates> {
-        return Promise.resolve({x: 0, y: 0, z: 0});
+        return Promise.resolve({ x: 0, y: 0, z: 0 });
     }
 
     public async getHeliocentricEclipticRectangularDateCoordinates(): Promise<RectangularCoordinates> {
-        return Promise.resolve({x: 0, y: 0, z: 0});
+        return Promise.resolve({ x: 0, y: 0, z: 0 });
     }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
-        return Promise.resolve({lon: 0, lat: 0, radiusVector: 0});
+        return Promise.resolve({ lon: 0, lat: 0, radiusVector: 0 });
     }
 
     public async getHeliocentricEclipticSphericalDateCoordinates(): Promise<EclipticSphericalCoordinates> {
-        return Promise.resolve({lon: 0, lat: 0, radiusVector: 0});
+        return Promise.resolve({ lon: 0, lat: 0, radiusVector: 0 });
     }
 
     public async getGeocentricEclipticRectangularJ2000Coordinates(): Promise<RectangularCoordinates> {

--- a/src/time/TimeOfInterest.ts
+++ b/src/time/TimeOfInterest.ts
@@ -1,18 +1,20 @@
+import { Time } from './timeTypes';
 import Location from '../earth/Location';
-import {timeCalc} from '../utils';
-import {Time} from './timeTypes';
+import { timeCalc } from '../utils';
 
 export default class TimeOfInterest {
-    public jd: number = 0.0;
-    public T: number = 0.0;
 
-    constructor(public time: Time) {
-        this.jd = timeCalc.time2julianDay(time);
-        this.T = timeCalc.julianDay2julianCenturiesJ2000(this.jd);
+    private readonly julianDay: number;
+
+    private readonly julianCenturies: number;
+
+    constructor(public readonly time: Time) {
+        this.julianDay = timeCalc.time2julianDay(time);
+        this.julianCenturies = timeCalc.julianDay2julianCenturiesJ2000(this.julianDay);
     }
 
     public getDate(): Date {
-        const {year, month, day, hour, min, sec} = this.time;
+        const { year, month, day, hour, min, sec } = this.time;
 
         return new Date(Date.UTC(year, month - 1, day, hour, min, sec));
     }
@@ -34,39 +36,39 @@ export default class TimeOfInterest {
     }
 
     public getJulianDay(): number {
-        return this.jd;
+        return this.julianDay;
     }
 
     public getJulianDay0(): number {
-        return timeCalc.julianDay2julianDay0(this.jd);
+        return timeCalc.julianDay2julianDay0(this.julianDay);
     }
 
     public getJulianCenturiesJ2000(): number {
-        return this.T;
+        return this.julianCenturies;
     }
 
     public getJulianMillenniaJ2000(): number {
-        return timeCalc.julianDay2julianMillenniaJ2000(this.jd);
+        return timeCalc.julianDay2julianMillenniaJ2000(this.julianDay);
     }
 
     public getGreenwichMeanSiderealTime(): number {
-        return timeCalc.getGreenwichMeanSiderealTime(this.T);
+        return timeCalc.getGreenwichMeanSiderealTime(this.julianCenturies);
     }
 
     public getGreenwichApparentSiderealTime(): number {
-        return timeCalc.getGreenwichApparentSiderealTime(this.T);
+        return timeCalc.getGreenwichApparentSiderealTime(this.julianCenturies);
     }
 
     public getLocalMeanSiderealTime(location: Location): number {
-        return timeCalc.getLocalMeanSiderealTime(this.T, location.lon);
+        return timeCalc.getLocalMeanSiderealTime(this.julianCenturies, location.lon);
     }
 
     public getLocalApparentSiderealTime(location: Location): number {
-        return timeCalc.getLocalApparentSiderealTime(this.T, location.lon);
+        return timeCalc.getLocalApparentSiderealTime(this.julianCenturies, location.lon);
     }
 
     public getDeltaT(): number {
-        const {year, month} = this.time;
+        const { year, month } = this.time;
 
         return timeCalc.getDeltaT(year, month);
     }


### PR DESCRIPTION
Hello Andreas,


First of all, thank you very much for your `astronomy-bundle-js` project! That's a very nice and interesting initiative!

I was looking for a library allowing to calculate the positions of celestial bodies in [my pet project](https://github.com/atelechev/astrocadre), choosing between [astronomia](https://github.com/commenthol/astronomia) and the yours. `astronomy-bundle-js` was much easier to integrate for my use case, it worked out-of-the-box, so your library will be used in my app soon in an upcoming version.

However, looking into the current implementation, with this pull request I'd like to suggest some minor improvements. For example:

* Several `public` mutable fields in different classes were properly encapsulated and set immutable by marking with `readonly`.

* The `AstronomicalObject.getName()` function was transformed into an imutable property: `get name(): string`. It is now initialized through a constuctor argument. The descendant classes were adjusted in order to pass the value.

* In the `TimeOfInterest` definition, I suggest changing the names of the fields for a bit more explicitness: `jd -> julianDay`, `T -> julianCenturies`.

* BTW, the import statements in the changed files were automatically sorted in my VSC.


All the tests continue to pass after these changes, so I suppose that the changes are not breaking.


I have also several ideas for more significant changes of the API and design choices:

* The (very) numerous accessor functions for `Coordinates` (like `getHeliocentricEclipticRectangularJ2000Coordinates` etc) make the API very verbose and somewhat bloated from the start. It would be more compact to have a `getCoordinates()` method and provide methods for conversions: for example, `getCoordinates().toHeliocentricEclipticRectangular()`. Or to inverse the approach and create a `CoordsCalculator` object with a `calculateCoordinates(AstronomicalObject, Referential, TimeOfInterest)` method.

* The `async` declarations on the `get*Coordinates` functions make them harder to use. It would be nice to avoid the `async` at this level, because the functions are declared to return `Promise`s, so they can already be used in asynchronous processing.

* I've noticed in the changelog that TS `interface`s were used previously, but then replaced with `type`s. Why this decision? For the case of the coordinates definitions, interfaces look more appropriate, because their usage will allow to define a hierarchy.

* For the `Earth` object implementation, it is strange to see the `Promise.reject` returned from `getGeocentric*Coordinates`. These coordinates are valid, they just point to the origin, although not very useful. Anyway, they do not resemble error cases to be rejected.


If you are interested, we can discuss these ideas and, probably, other pull requests will follow.


Kind regards,

Anton