### PR TITLE
refactor(planet): Planet - add diameter property, move getAngularDiameter()

### DIFF
--- a/src/planets/Jupiter.ts
+++ b/src/planets/Jupiter.ts
@@ -1,6 +1,5 @@
 import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
 import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {observationCalc} from '../utils';
 import {DIAMETER_JUPITER} from '../constants/diameters';
 import {EclipticSphericalCoordinates} from '../coordinates/types/CoordinateTypes';
 import {normalizeAngle} from '../utils/angleCalc';
@@ -11,6 +10,10 @@ import Planet from './Planet';
 export default class Jupiter extends Planet {
     constructor(toi?: TimeOfInterest, useVsop87Short?: boolean) {
         super('jupiter', toi, useVsop87Short);
+    }
+
+    public get diameter(): number {
+        return DIAMETER_JUPITER;
     }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
@@ -37,12 +40,6 @@ export default class Jupiter extends Planet {
                 radiusVector: calculateVSOP87(vsop87.VSOP87_Z, this.t),
             };
         });
-    }
-
-    public async getAngularDiameter(): Promise<number> {
-        const distance = await this.getApparentDistanceToEarth();
-
-        return observationCalc.getAngularDiameter(distance, DIAMETER_JUPITER);
     }
 
     public async getApparentMagnitude(): Promise<number> {

--- a/src/planets/Mars.ts
+++ b/src/planets/Mars.ts
@@ -1,6 +1,5 @@
 import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
 import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {observationCalc} from '../utils';
 import {DIAMETER_MARS} from '../constants/diameters';
 import {EclipticSphericalCoordinates} from '../coordinates/types/CoordinateTypes';
 import {normalizeAngle} from '../utils/angleCalc';
@@ -11,6 +10,10 @@ import Planet from './Planet';
 export default class Mars extends Planet {
     constructor(toi?: TimeOfInterest, useVsop87Short?: boolean) {
         super('mars', toi, useVsop87Short);
+    }
+
+    public get diameter(): number {
+        return DIAMETER_MARS;
     }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
@@ -37,12 +40,6 @@ export default class Mars extends Planet {
                 radiusVector: calculateVSOP87(vsop87.VSOP87_Z, this.t),
             };
         });
-    }
-
-    public async getAngularDiameter(): Promise<number> {
-        const distance = await this.getApparentDistanceToEarth();
-
-        return observationCalc.getAngularDiameter(distance, DIAMETER_MARS);
     }
 
     public async getApparentMagnitude(): Promise<number> {

--- a/src/planets/Mercury.ts
+++ b/src/planets/Mercury.ts
@@ -1,6 +1,5 @@
 import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
 import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {observationCalc} from '../utils';
 import {DIAMETER_MERCURY} from '../constants/diameters';
 import {EclipticSphericalCoordinates} from '../coordinates/types/CoordinateTypes';
 import {normalizeAngle} from '../utils/angleCalc';
@@ -11,6 +10,10 @@ import Planet from './Planet';
 export default class Mercury extends Planet {
     constructor(toi?: TimeOfInterest, useVsop87Short?: boolean) {
         super('mercury', toi, useVsop87Short);
+    }
+
+    public get diameter(): number {
+        return DIAMETER_MERCURY;
     }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
@@ -37,12 +40,6 @@ export default class Mercury extends Planet {
                 radiusVector: calculateVSOP87(vsop87.VSOP87_Z, this.t),
             };
         });
-    }
-
-    public async getAngularDiameter(): Promise<number> {
-        const distance = await this.getApparentDistanceToEarth();
-
-        return observationCalc.getAngularDiameter(distance, DIAMETER_MERCURY);
     }
 
     public async getApparentMagnitude(): Promise<number> {

--- a/src/planets/Neptune.ts
+++ b/src/planets/Neptune.ts
@@ -1,6 +1,5 @@
 import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
 import {getAsyncCachedCalculation} from '../cache/calculationCache';
-import {observationCalc} from '../utils';
 import {DIAMETER_NEPTUNE} from '../constants/diameters';
 import {EclipticSphericalCoordinates} from '../coordinates/types/CoordinateTypes';
 import {normalizeAngle} from '../utils/angleCalc';
@@ -11,6 +10,10 @@ import Planet from './Planet';
 export default class Neptune extends Planet {
     constructor(toi?: TimeOfInterest, useVsop87Short?: boolean) {
         super('neptune', toi, useVsop87Short);
+    }
+
+    public get diameter(): number {
+        return DIAMETER_NEPTUNE;
     }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
@@ -37,12 +40,6 @@ export default class Neptune extends Planet {
                 radiusVector: calculateVSOP87(vsop87.VSOP87_Z, this.t),
             };
         });
-    }
-
-    public async getAngularDiameter(): Promise<number> {
-        const distance = await this.getApparentDistanceToEarth();
-
-        return observationCalc.getAngularDiameter(distance, DIAMETER_NEPTUNE);
     }
 
     public async getApparentMagnitude(): Promise<number> {

--- a/src/planets/Planet.ts
+++ b/src/planets/Planet.ts
@@ -42,6 +42,14 @@ export default abstract class Planet extends AstronomicalObject implements IPlan
         this.earth = createEarth(toi);
     }
 
+    public abstract get diameter(): number;
+
+    public async getAngularDiameter(): Promise<number> {
+        const distance = await this.getApparentDistanceToEarth();
+
+        return observationCalc.getAngularDiameter(distance, this.diameter);
+    }
+
     public async getHeliocentricEclipticRectangularJ2000Coordinates(): Promise<RectangularCoordinates> {
         const coords = await this.getHeliocentricEclipticSphericalJ2000Coordinates();
 

--- a/src/planets/Saturn.ts
+++ b/src/planets/Saturn.ts
@@ -1,6 +1,5 @@
 import {getAsyncCachedCalculation} from '../cache/calculationCache';
 import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {observationCalc} from '../utils';
 import {DIAMETER_SATURN} from '../constants/diameters';
 import {EclipticSphericalCoordinates} from '../coordinates/types/CoordinateTypes';
 import {normalizeAngle} from '../utils/angleCalc';
@@ -11,6 +10,10 @@ import Planet from './Planet';
 export default class Saturn extends Planet {
     constructor(toi?: TimeOfInterest, useVsop87Short?: boolean) {
         super('saturn', toi, useVsop87Short);
+    }
+
+    public get diameter(): number {
+        return DIAMETER_SATURN;
     }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
@@ -37,12 +40,6 @@ export default class Saturn extends Planet {
                 radiusVector: calculateVSOP87(vsop87.VSOP87_Z, this.t),
             };
         });
-    }
-
-    public async getAngularDiameter(): Promise<number> {
-        const distance = await this.getApparentDistanceToEarth();
-
-        return observationCalc.getAngularDiameter(distance, DIAMETER_SATURN);
     }
 
     public async getApparentMagnitude(): Promise<number> {

--- a/src/planets/Uranus.ts
+++ b/src/planets/Uranus.ts
@@ -1,6 +1,5 @@
 import {getAsyncCachedCalculation} from '../cache/calculationCache';
 import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {observationCalc} from '../utils';
 import {DIAMETER_URANUS} from '../constants/diameters';
 import {EclipticSphericalCoordinates} from '../coordinates/types/CoordinateTypes';
 import {normalizeAngle} from '../utils/angleCalc';
@@ -11,6 +10,10 @@ import Planet from './Planet';
 export default class Uranus extends Planet {
     constructor(toi?: TimeOfInterest, useVsop87Short?: boolean) {
         super('uranus', toi, useVsop87Short);
+    }
+
+    public get diameter(): number {
+        return DIAMETER_URANUS;
     }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
@@ -37,12 +40,6 @@ export default class Uranus extends Planet {
                 radiusVector: calculateVSOP87(vsop87.VSOP87_Z, this.t),
             };
         });
-    }
-
-    public async getAngularDiameter(): Promise<number> {
-        const distance = await this.getApparentDistanceToEarth();
-
-        return observationCalc.getAngularDiameter(distance, DIAMETER_URANUS);
     }
 
     public async getApparentMagnitude(): Promise<number> {

--- a/src/planets/Venus.ts
+++ b/src/planets/Venus.ts
@@ -1,6 +1,5 @@
 import {getAsyncCachedCalculation} from '../cache/calculationCache';
 import {calculateVSOP87, calculateVSOP87Angle} from '../utils/vsop87Calc';
-import {observationCalc} from '../utils';
 import {DIAMETER_VENUS} from '../constants/diameters';
 import {normalizeAngle} from '../utils/angleCalc';
 import {EclipticSphericalCoordinates} from '../coordinates/types/CoordinateTypes';
@@ -11,6 +10,10 @@ import Planet from './Planet';
 export default class Venus extends Planet {
     constructor(toi?: TimeOfInterest, useVsop87Short?: boolean) {
         super('venus', toi, useVsop87Short);
+    }
+
+    public get diameter(): number {
+        return DIAMETER_VENUS;
     }
 
     public async getHeliocentricEclipticSphericalJ2000Coordinates(): Promise<EclipticSphericalCoordinates> {
@@ -37,12 +40,6 @@ export default class Venus extends Planet {
                 radiusVector: calculateVSOP87(vsop87.VSOP87_Z, this.t),
             };
         });
-    }
-
-    public async getAngularDiameter(): Promise<number> {
-        const distance = await this.getApparentDistanceToEarth();
-
-        return observationCalc.getAngularDiameter(distance, DIAMETER_VENUS);
     }
 
     public async getApparentMagnitude(): Promise<number> {


### PR DESCRIPTION
Before the changes, the `getAngularDiameter()` function existed in each descendant of the `Planet` class. The implementations differed only in the values of the respective planet's diameter.

Changes:

* A new `diameter` property was introduced into the `Planet` class. It uses the respective values from `constants/diameters`. (these constants can be candidates for removal).

* Only one implementation of the `getAngularDiameter()` function remains in `Planet`.