### PR TITLE
feat(lunar-limb-profile): add lunar limb profile package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A TypeScript library for astronomical calculations including the position of the
 - [`@astronomy-bundle/sun`](https://www.npmjs.com/package/@astronomy-bundle/sun)
 - [`@astronomy-bundle/planets`](https://www.npmjs.com/package/@astronomy-bundle/planets)
 - [`@astronomy-bundle/solar-eclipse`](https://www.npmjs.com/package/@astronomy-bundle/solar-eclipse)
+- [`@astronomy-bundle/lunar-limb-profile`](https://www.npmjs.com/package/@astronomy-bundle/lunar-limb-profile)
 
 ## API Reference
 
@@ -24,3 +25,4 @@ A TypeScript library for astronomical calculations including the position of the
 | **Sun** | The `Sun` object — geocentric coordinates, apparent and observed topocentric coordinates, rise, transit and set times, angular diameter, light time, and apparent magnitude. | [README](packages/sun/README.md) |
 | **Planets** | The `Mercury`, `Venus`, `Mars`, `Jupiter`, `Saturn`, `Uranus`, and `Neptune` objects — heliocentric, geocentric, apparent, and topocentric planetary coordinates, rise, transit and set times, plus distance, light time, phase, elongation, and magnitude. | [README](packages/planets/README.md) |
 | **Solar Eclipse** | Solar eclipse calculations from Besselian elements — global circumstances (eclipse type, time and location of greatest eclipse, magnitude, obscuration, Moon/Sun ratio, and the central line path) and local circumstances for any observer (local type, contact times, magnitude, obscuration, duration, and the Sun's position at a given moment). Ships with built-in catalogues covering 1900–2100 and −1999–3000. | [README](packages/solarEclipse/README.md) |
+| **Lunar Limb Profile** | The `LunarLimbProfile` object — height of the Moon's visible limb silhouette from LOLA/LDEM terrain data, evaluated in perspective from the observer's distance at a celestial position angle. Useful for occultations, grazing occultations, and Baily's beads. | [README](packages/lunarLimbProfile/README.md) |

--- a/packages.config.ts
+++ b/packages.config.ts
@@ -5,4 +5,5 @@ export default [
     'packages/planets',
     'packages/sun',
     'packages/solarEclipse',
+    'packages/lunarLimbProfile',
 ];

--- a/packages/lunarLimbProfile/README.md
+++ b/packages/lunarLimbProfile/README.md
@@ -1,0 +1,99 @@
+Part of the [Astronomy Bundle](../../README.md).
+
+# Lunar Limb Profile
+
+The `lunar-limb-profile` package provides the `LunarLimbProfile` object for computing the height of the Moon's visible limb silhouette from LOLA/LDEM terrain data. Given a libration state and the observer's distance, it evaluates the apparent terrain radius along the line of sight and returns the limb height above the LDEM reference sphere at a celestial position angle. This is useful for modelling the irregular lunar limb in occultations, grazing occultations, and the Baily's beads phase of a solar eclipse.
+
+## Contents
+
+- [Install](#install)
+- [Terrain data](#terrain-data)
+- [API Reference](#api-reference)
+  - [Create the lunar limb profile](#create-the-lunar-limb-profile)
+  - [Reference radius](#reference-radius)
+  - [Limb height at a position angle](#limb-height-at-a-position-angle)
+
+## Install
+
+With npm: `npm install @astronomy-bundle/lunar-limb-profile`\
+With yarn: `yarn add @astronomy-bundle/lunar-limb-profile`\
+With pnpm: `pnpm add @astronomy-bundle/lunar-limb-profile`
+
+## Terrain data
+
+The profile is derived from the LOLA Lunar Digital Elevation Model (LDEM), distributed as a raw 16-bit little-endian raster (`.img`) alongside a PDS label (`.lbl`) that describes the grid geometry. Both are passed to `create` as plain data — reading them from disk (or fetching them over the network) is the caller's responsibility. The `ldem_16` product (16 pixels/degree) is a good default; higher-resolution products such as `ldem_64` trade a much larger file for finer detail.
+
+The datasets can be downloaded from the LRO/LOLA GDR DEM archive: <https://ode.rsl.wustl.edu/moon/pagehelp/Content/Missions_Instruments/LRO/LOLA/GDR/GDRDEM.htm>
+
+## API Reference
+
+### Create the lunar limb profile
+
+**Description:** The `LunarLimbProfile` object is created from the LDEM raster bytes and the text of its PDS label. The label is parsed immediately to derive the grid geometry; the raster is validated against that geometry on first use.
+
+**Example**: Create a lunar limb profile from the `ldem_16` product
+
+```javascript
+import {readFileSync} from 'node:fs';
+import {LunarLimbProfile} from '@astronomy-bundle/lunar-limb-profile';
+
+const imgData = readFileSync('ldem_16.img');
+const label = readFileSync('ldem_16.lbl', 'utf8');
+
+const profile = LunarLimbProfile.create(imgData, label);
+```
+
+---
+
+### Reference radius
+
+**Description:** `getReferenceRadiusKm()` returns the radius of the LDEM reference sphere in kilometres. Limb heights are measured relative to this sphere.
+
+**Example**: Get the reference radius
+
+```javascript
+import {readFileSync} from 'node:fs';
+import {LunarLimbProfile} from '@astronomy-bundle/lunar-limb-profile';
+
+const profile = LunarLimbProfile.create(readFileSync('ldem_16.img'), readFileSync('ldem_16.lbl', 'utf8'));
+
+const referenceRadiusKm = profile.getReferenceRadiusKm();
+```
+
+The result of the calculation should be:\
+Reference radius: *1737.4 km*
+
+---
+
+### Limb height at a position angle
+
+**Description:** `heightKm(positionAngleDeg, libration, axisPositionAngleDeg, observerDistanceKm)` returns the height of the visible limb silhouette in kilometres — the maximum apparent terrain radius along the line of sight, in perspective from the given observer distance — above the apparent radius of the LDEM reference sphere, at the given celestial position angle.
+
+- `positionAngleDeg` — celestial position angle of the limb point, measured eastward from the north point of the disk.
+- `libration` — the Moon's optical libration as `{longitude, latitude}` in degrees.
+- `axisPositionAngleDeg` — position angle of the Moon's axis of rotation, used to rotate the celestial position angle into the selenographic frame.
+- `observerDistanceKm` — distance from the observer to the Moon in kilometres.
+
+**Example**: Get the limb height at several position angles
+
+```javascript
+import {readFileSync} from 'node:fs';
+import {LunarLimbProfile} from '@astronomy-bundle/lunar-limb-profile';
+
+const profile = LunarLimbProfile.create(readFileSync('ldem_16.img'), readFileSync('ldem_16.lbl', 'utf8'));
+
+const libration = {longitude: 2.0, latitude: -0.1};
+const axisPositionAngleDeg = 340;
+const observerDistanceKm = 380000;
+
+const north = profile.heightKm(0, libration, axisPositionAngleDeg, observerDistanceKm);
+const east  = profile.heightKm(90, libration, axisPositionAngleDeg, observerDistanceKm);
+const south = profile.heightKm(180, libration, axisPositionAngleDeg, observerDistanceKm);
+const west  = profile.heightKm(270, libration, axisPositionAngleDeg, observerDistanceKm);
+```
+
+The result of the calculation should be:\
+Height at PA 0°: *-0.185596 km*\
+Height at PA 90°: *2.115692 km*\
+Height at PA 180°: *1.296247 km*\
+Height at PA 270°: *-0.927427 km*

--- a/packages/lunarLimbProfile/index.ts
+++ b/packages/lunarLimbProfile/index.ts
@@ -1,0 +1,1 @@
+export {default as LunarLimbProfile} from './models/LunarLimbProfile';

--- a/packages/lunarLimbProfile/models/LunarLimbProfile.test.ts
+++ b/packages/lunarLimbProfile/models/LunarLimbProfile.test.ts
@@ -1,0 +1,31 @@
+import {readFileSync} from 'node:fs';
+import {join} from 'node:path';
+
+import LunarLimbProfile from './LunarLimbProfile';
+
+const imgData = readFileSync(join(__dirname, '../resources/ldem_16.img'));
+const label = readFileSync(join(__dirname, '../resources/ldem_16.lbl'), 'utf8');
+
+it('reads the reference radius from the label', () => {
+    const profile = LunarLimbProfile.create(imgData, label);
+
+    expect(profile.getReferenceRadiusKm()).toBeCloseTo(1737.4, 6);
+});
+
+it('returns finite limb heights of lunar-relief magnitude across position angles', () => {
+    const profile = LunarLimbProfile.create(imgData, label);
+    const libration = {longitude: 2.0, latitude: -0.1};
+
+    for (let positionAngleDeg = 0; positionAngleDeg < 360; positionAngleDeg += 5) {
+        const height = profile.heightKm(positionAngleDeg, libration, 340, 380000);
+        expect(Number.isFinite(height)).toBe(true);
+        expect(Math.abs(height)).toBeLessThan(10);
+    }
+});
+
+it('throws when the image does not match the label geometry', () => {
+    // Feed the (much smaller) label bytes as the raster so it fails the size check.
+    const profile = LunarLimbProfile.create(readFileSync(join(__dirname, '../resources/ldem_16.lbl')), label);
+
+    expect(() => profile.heightKm(0, {longitude: 0, latitude: 0}, 0, 380000)).toThrow(/size mismatch/);
+});

--- a/packages/lunarLimbProfile/models/LunarLimbProfile.ts
+++ b/packages/lunarLimbProfile/models/LunarLimbProfile.ts
@@ -1,0 +1,51 @@
+import type {LdemGeometry} from '../types/LdemTypes';
+import type {LunarLibration} from '../types/LunarLimbTypes';
+import {parseLdemLabel} from '../utils/ldemLabel';
+import {getLimbHeightKm} from '../utils/limbProfile';
+
+export default class LunarLimbProfile implements LunarLimbProfile {
+    private grid: Int16Array | null = null;
+
+    private constructor(
+        private readonly imgData: Uint8Array,
+        private readonly geometry: LdemGeometry,
+    ) {}
+
+    public static create(imgData: Uint8Array, label: string): LunarLimbProfile {
+        return new LunarLimbProfile(imgData, parseLdemLabel(label));
+    }
+
+    public getReferenceRadiusKm(): number {
+        return this.geometry.referenceRadiusM / 1000;
+    }
+
+    public heightKm(
+        positionAngleDeg: number,
+        libration: LunarLibration,
+        axisPositionAngleDeg: number,
+        observerDistanceKm: number,
+    ): number {
+        return getLimbHeightKm(
+            this.loadGrid(),
+            this.geometry,
+            positionAngleDeg,
+            libration,
+            axisPositionAngleDeg,
+            observerDistanceKm,
+        );
+    }
+
+    private loadGrid(): Int16Array {
+        if (this.grid !== null) {
+            return this.grid;
+        }
+
+        const {rows, cols} = this.geometry;
+        if (this.imgData.length !== rows * cols * 2) {
+            throw new Error(`LDEM size mismatch: expected ${rows * cols * 2}, got ${this.imgData.length}`);
+        }
+        this.grid = new Int16Array(this.imgData.buffer, this.imgData.byteOffset, rows * cols);
+
+        return this.grid;
+    }
+}

--- a/packages/lunarLimbProfile/package.json
+++ b/packages/lunarLimbProfile/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "@astronomy-bundle/lunar-limb-profile",
+    "description": "Lunar limb profile from LOLA/LDEM terrain for the astronomy bundle",
+    "private": true
+}

--- a/packages/lunarLimbProfile/resources/ldem_16.lbl
+++ b/packages/lunarLimbProfile/resources/ldem_16.lbl
@@ -1,0 +1,109 @@
+PDS_VERSION_ID            = "PDS3"
+
+/*** GENERAL DATA DESCRIPTION PARAMETERS ***/
+PRODUCT_VERSION_ID        = "V3.1"
+DATA_SET_ID               = "LRO-L-LOLA-4-GDR-V1.0"
+PRODUCT_ID                = "LDEM_16"
+INSTRUMENT_HOST_NAME      = "LUNAR RECONNAISSANCE ORBITER"
+INSTRUMENT_NAME           = "LUNAR ORBITER LASER ALTIMETER"
+INSTRUMENT_ID             = "LOLA"
+MISSION_PHASE_NAME        = {"COMMISSIONING","NOMINAL MISSION","SCIENCE
+                            MISSION","EXTENDED SCIENCE MISSION",
+                            "SECOND EXTENDED SCIENCE MISSION","THIRD
+                            EXTENDED SCIENCE MISSION"} 
+TARGET_NAME               = MOON
+START_TIME                = 2009-07-13T17:33:17
+STOP_TIME                 = 2016-11-29T05:48:19
+PRODUCT_CREATION_TIME     = 2019-03-15
+PRODUCER_ID               = LRO_LOLA_TEAM
+PRODUCER_FULL_NAME        = "DAVID E. SMITH"
+PRODUCER_INSTITUTION_NAME = "GODDARD SPACE FLIGHT CENTER"
+DESCRIPTION               = "This data product is a shape map (radius)
+   of the Moon at a resolution of 1895.21 m/pix by 1895.21 m/pix,
+   based on altimetry data acquired through mission phase LRO_ES_52
+   by the LOLA instrument. All LOLA data used for the generation of 
+   this GDR products are geolocated using precision orbits based on a 
+   revised lunar gravity field GRGM 900C[LEMOINEETAL2014].  The previous
+   version of this product was generated with data through LRO_ES_21.
+   An additional 505,763,339 data points have been added.
+
+   The gridfiles were produced in 45 degree latitude bands, and there 
+   may be edge artifacts at this boundary.  Unlike previous versions of
+   these products, the Generic Mapping Tools (GMT) program 'grdblend' was 
+   not used.  At higher resolutions, the GMT5.4.2 program 'surface' was
+   used to compensate for incomplete coverage. Tension was set to 0.5
+   and Anisotropy to 0.5 to minimize latitude distortion. The map is in
+   the form of a binary table with one row for each 0.0625 degrees of 
+   latitude, pixel registered.  Map values are relative to a radius of 
+   1737.4 km.
+
+   This label describes an IMG file in the form of a binary resampling
+   to pixel registration.
+"
+
+OBJECT                    = UNCOMPRESSED_FILE
+FILE_NAME                 = "LDEM_16.IMG"
+RECORD_TYPE               = FIXED_LENGTH
+FILE_RECORDS              = 2880
+RECORD_BYTES              = 11520
+^IMAGE                    = "LDEM_16.IMG"
+
+
+  OBJECT                  = IMAGE
+    NAME                  = HEIGHT
+    DESCRIPTION           = "Each sample represents height relative to a
+      reference radius (OFFSET) and is generated using geolocated LOLA data
+      produced by the LOLA team."
+    LINES                 = 2880
+    LINE_SAMPLES          = 5760
+    MAXIMUM               = 21580
+    MINIMUM               = -18150
+    SAMPLE_TYPE           = LSB_INTEGER
+    SAMPLE_BITS           = 16
+    UNIT                  = METER
+    SCALING_FACTOR        = 0.5
+    OFFSET                = 1737400.
+
+/* NOTE:                                                                   */
+/* Conversion from Digital Number to HEIGHT, i.e. elevation in meters, is: */
+/* HEIGHT = (DN * SCALING_FACTOR).                                         */
+/* The conversion from Digital Number to PLANETARY_RADIUS in meters is:    */
+/* PLANETARY_RADIUS = (DN * SCALING_FACTOR) + OFFSET                       */
+/* where OFFSET is the radius of a reference sphere.                       */
+/* The planetopotential TOPOGRAPHY is PLANETARY_RADIUS - GEOID_RADIUS,     */
+/* where GEOID_RADIUS is derived from a gravitational equipotential model. */
+/* By convention, the average GEOID_RADIUS at the equator is OFFSET.       */
+
+  END_OBJECT              = IMAGE
+END_OBJECT                = UNCOMPRESSED_FILE
+OBJECT                    = IMAGE_MAP_PROJECTION
+ ^DATA_SET_MAP_PROJECTION     = "DSMAP.CAT"
+ MAP_PROJECTION_TYPE          = "SIMPLE CYLINDRICAL"
+ MAP_RESOLUTION               = 16 <pix/deg>
+ A_AXIS_RADIUS                = 1737.4 <km>
+ B_AXIS_RADIUS                = 1737.4 <km>
+ C_AXIS_RADIUS                = 1737.4 <km>
+ FIRST_STANDARD_PARALLEL      = 'N/A'
+ SECOND_STANDARD_PARALLEL     = 'N/A'
+ POSITIVE_LONGITUDE_DIRECTION = "EAST"
+ CENTER_LATITUDE              = 0 <deg>
+ CENTER_LONGITUDE             = 180 <deg>
+ REFERENCE_LATITUDE           = 'N/A'
+ REFERENCE_LONGITUDE          = 'N/A'
+ LINE_FIRST_PIXEL             = 1
+ LINE_LAST_PIXEL              = 2880
+ SAMPLE_FIRST_PIXEL           = 1
+ SAMPLE_LAST_PIXEL            = 5760
+ MAP_PROJECTION_ROTATION      = 0.0
+ MAP_SCALE                    = 1895.21 <m/pix>
+ MAXIMUM_LATITUDE             = 90 <deg>
+ MINIMUM_LATITUDE             = -90 <deg>
+ WESTERNMOST_LONGITUDE        = 0 <deg>
+ EASTERNMOST_LONGITUDE        = 360 <deg>
+ LINE_PROJECTION_OFFSET       = 1439.5 <pix>
+ SAMPLE_PROJECTION_OFFSET     = 2879.5 <pix>
+ COORDINATE_SYSTEM_TYPE       = "BODY-FIXED ROTATING"
+ COORDINATE_SYSTEM_NAME       = "MEAN EARTH/POLAR AXIS OF DE421"
+END_OBJECT                    = IMAGE_MAP_PROJECTION
+
+END

--- a/packages/lunarLimbProfile/types/LdemTypes.ts
+++ b/packages/lunarLimbProfile/types/LdemTypes.ts
@@ -1,0 +1,9 @@
+export interface LdemGeometry {
+    rows: number;
+    cols: number;
+    degPerPixel: number;
+    latFirst: number;
+    lonFirst: number;
+    scalingFactorM: number;
+    referenceRadiusM: number;
+}

--- a/packages/lunarLimbProfile/types/LunarLimbTypes.ts
+++ b/packages/lunarLimbProfile/types/LunarLimbTypes.ts
@@ -1,0 +1,16 @@
+export interface LunarLibration {
+    longitude: number;
+    latitude: number;
+}
+
+export interface LunarLimbProfile {
+    // Height of the visible limb silhouette (maximum apparent terrain radius along the line of sight, in
+    // perspective from the given observer distance) above the apparent radius of the LDEM reference
+    // sphere, at the given celestial position angle.
+    heightKm(
+        positionAngleDeg: number,
+        libration: LunarLibration,
+        axisPositionAngleDeg: number,
+        observerDistanceKm: number,
+    ): number;
+}

--- a/packages/lunarLimbProfile/utils/ldemLabel.test.ts
+++ b/packages/lunarLimbProfile/utils/ldemLabel.test.ts
@@ -1,0 +1,28 @@
+import {readFileSync} from 'node:fs';
+import {join} from 'node:path';
+
+import {parseLdemLabel} from './ldemLabel';
+
+const label = readFileSync(join(__dirname, '../resources/ldem_16.lbl'), 'utf8');
+
+it('derives the ldem_16 grid geometry that the loader previously hardcoded', () => {
+    const geometry = parseLdemLabel(label);
+
+    expect(geometry.rows).toBe(2880);
+    expect(geometry.cols).toBe(5760);
+    expect(geometry.degPerPixel).toBe(1 / 16);
+    expect(geometry.latFirst).toBeCloseTo(90 - 1 / 32, 12);
+    expect(geometry.lonFirst).toBeCloseTo(1 / 32, 12);
+    expect(geometry.scalingFactorM).toBe(0.5);
+    expect(geometry.referenceRadiusM).toBe(1737400);
+});
+
+it('rejects a label whose samples are not 16-bit LSB integers', () => {
+    const patched = label.replace(/SAMPLE_BITS\s*=\s*16/, 'SAMPLE_BITS = 32');
+    expect(() => parseLdemLabel(patched)).toThrow(/16-bit LSB/);
+});
+
+it('throws on a missing keyword', () => {
+    const patched = label.replace(/MAP_RESOLUTION.*/, '');
+    expect(() => parseLdemLabel(patched)).toThrow(/MAP_RESOLUTION/);
+});

--- a/packages/lunarLimbProfile/utils/ldemLabel.ts
+++ b/packages/lunarLimbProfile/utils/ldemLabel.ts
@@ -1,0 +1,51 @@
+import type {LdemGeometry} from '../types/LdemTypes';
+
+export function parseLdemLabel(label: string): LdemGeometry {
+    const sampleBits = numberField(label, 'SAMPLE_BITS');
+    const sampleType = textField(label, 'SAMPLE_TYPE');
+    if (sampleBits !== 16 || !/LSB/.test(sampleType)) {
+        throw new Error(`LDEM label: expected 16-bit LSB samples, got ${sampleBits}-bit ${sampleType}`);
+    }
+
+    const mapResolution = numberField(label, 'MAP_RESOLUTION');
+    const degPerPixel = 1 / mapResolution;
+
+    // In the PDS simple-cylindrical projection the projection offsets give the pixel of the map centre,
+    // so row/col 0 sit CENTER +/- offset * degPerPixel away from it.
+    const latFirst = numberField(label, 'CENTER_LATITUDE') + numberField(label, 'LINE_PROJECTION_OFFSET') * degPerPixel;
+    const lonFirst =
+        numberField(label, 'CENTER_LONGITUDE') - numberField(label, 'SAMPLE_PROJECTION_OFFSET') * degPerPixel;
+
+    return {
+        rows: numberField(label, 'LINES'),
+        cols: numberField(label, 'LINE_SAMPLES'),
+        degPerPixel,
+        latFirst,
+        lonFirst,
+        scalingFactorM: numberField(label, 'SCALING_FACTOR'),
+        referenceRadiusM: numberField(label, 'OFFSET'),
+    };
+}
+
+function numberField(label: string, key: string): number {
+    const raw = field(label, key);
+    const value = Number.parseFloat(raw);
+    if (Number.isNaN(value)) {
+        throw new Error(`LDEM label: ${key} is not a number (${raw})`);
+    }
+
+    return value;
+}
+
+function textField(label: string, key: string): string {
+    return field(label, key).replace(/^"|"$/g, '');
+}
+
+function field(label: string, key: string): string {
+    const match = label.match(new RegExp(`^\\s*${key}\\s*=\\s*(\\S+)`, 'm'));
+    if (!match) {
+        throw new Error(`LDEM label: missing ${key}`);
+    }
+
+    return match[1];
+}

--- a/packages/lunarLimbProfile/utils/limbProfile.test.ts
+++ b/packages/lunarLimbProfile/utils/limbProfile.test.ts
@@ -1,0 +1,32 @@
+import type {LdemGeometry} from '../types/LdemTypes';
+import {getLimbHeightKm} from './limbProfile';
+
+const geometry: LdemGeometry = {
+    rows: 180,
+    cols: 360,
+    degPerPixel: 1,
+    latFirst: 89.5,
+    lonFirst: 0.5,
+    scalingFactorM: 0.5,
+    referenceRadiusM: 1737400,
+};
+
+const libration = {longitude: 2.0, latitude: -0.1};
+
+it('reports ~zero height above the reference sphere for flat terrain', () => {
+    const flat = new Int16Array(geometry.rows * geometry.cols); // all zeros -> surface on the sphere
+
+    for (let pa = 0; pa < 360; pa += 30) {
+        expect(getLimbHeightKm(flat, geometry, pa, libration, 340, 380000)).toBeCloseTo(0, 2);
+    }
+});
+
+it('lifts the silhouette by a uniform terrain elevation', () => {
+    const dn = 4000; // 4000 * 0.5 m = 2 km everywhere
+    const raised = new Int16Array(geometry.rows * geometry.cols).fill(dn);
+
+    const height = getLimbHeightKm(raised, geometry, 90, libration, 340, 380000);
+
+    expect(height).toBeGreaterThan(1.9);
+    expect(height).toBeLessThan(2.1);
+});

--- a/packages/lunarLimbProfile/utils/limbProfile.ts
+++ b/packages/lunarLimbProfile/utils/limbProfile.ts
@@ -1,0 +1,109 @@
+import {DEG, RAD} from '@app/constants/math';
+import type {LdemGeometry} from '../types/LdemTypes';
+import type {LunarLibration} from '../types/LunarLimbTypes';
+
+const SILHOUETTE_PSI_MIN_DEG = 87;
+const SILHOUETTE_PSI_MAX_DEG = 93;
+const SILHOUETTE_PSI_STEP_DEG = 0.02;
+
+export function getLimbHeightKm(
+    grid: Int16Array,
+    geometry: LdemGeometry,
+    positionAngleDeg: number,
+    libration: LunarLibration,
+    axisPositionAngleDeg: number,
+    observerDistanceKm: number,
+): number {
+    const paFromLunarNorth = positionAngleDeg - axisPositionAngleDeg;
+    const observerDistanceM = observerDistanceKm * 1000;
+    const referenceRadiusM = geometry.referenceRadiusM;
+
+    let maxApparentM = -Infinity;
+    for (let psi = SILHOUETTE_PSI_MIN_DEG; psi <= SILHOUETTE_PSI_MAX_DEG; psi += SILHOUETTE_PSI_STEP_DEG) {
+        const {lat, lon} = limbPointSelenographic(paFromLunarNorth, psi, libration);
+        const surfaceRadiusM = referenceRadiusM + heightMetersAt(grid, geometry, lat, lon);
+        const apparentM = apparentRadiusM(surfaceRadiusM, psi * DEG, observerDistanceM);
+        if (apparentM > maxApparentM) {
+            maxApparentM = apparentM;
+        }
+    }
+
+    return (maxApparentM - referenceApparentRadiusM(referenceRadiusM, observerDistanceM)) / 1000;
+}
+
+function heightMetersAt(grid: Int16Array, geometry: LdemGeometry, latDeg: number, lonDeg: number): number {
+    const {degPerPixel, latFirst, lonFirst, scalingFactorM} = geometry;
+    const lonEast = ((lonDeg % 360) + 360) % 360;
+    const rowFloat = (latFirst - latDeg) / degPerPixel;
+    const colFloat = (lonEast - lonFirst) / degPerPixel;
+    const row0 = Math.floor(rowFloat);
+    const col0 = Math.floor(colFloat);
+    const rowFrac = rowFloat - row0;
+    const colFrac = colFloat - col0;
+
+    const v00 = sample(grid, geometry, row0, col0);
+    const v01 = sample(grid, geometry, row0, col0 + 1);
+    const v10 = sample(grid, geometry, row0 + 1, col0);
+    const v11 = sample(grid, geometry, row0 + 1, col0 + 1);
+
+    const top = v00 + (v01 - v00) * colFrac;
+    const bottom = v10 + (v11 - v10) * colFrac;
+    const dn = top + (bottom - top) * rowFrac;
+
+    return dn * scalingFactorM;
+}
+
+function sample(grid: Int16Array, geometry: LdemGeometry, row: number, col: number): number {
+    const {rows, cols} = geometry;
+    const wrappedCol = ((col % cols) + cols) % cols;
+    const clampedRow = Math.max(0, Math.min(rows - 1, row));
+
+    return grid[clampedRow * cols + wrappedCol];
+}
+
+function apparentRadiusM(surfaceRadiusM: number, psiRad: number, observerDistanceM: number): number {
+    return (
+        (surfaceRadiusM * Math.sin(psiRad) * observerDistanceM)
+        / (observerDistanceM - surfaceRadiusM * Math.cos(psiRad))
+    );
+}
+
+function referenceApparentRadiusM(referenceRadiusM: number, observerDistanceM: number): number {
+    const psiTangent = Math.acos(referenceRadiusM / observerDistanceM);
+
+    return apparentRadiusM(referenceRadiusM, psiTangent, observerDistanceM);
+}
+
+function limbPointSelenographic(
+    positionAngleFromLunarNorthDeg: number,
+    angularDistanceDeg: number,
+    libration: LunarLibration,
+): {lat: number; lon: number} {
+    const pa = positionAngleFromLunarNorthDeg * DEG;
+    const psi = angularDistanceDeg * DEG;
+    const libL = libration.longitude * DEG;
+    const libB = libration.latitude * DEG;
+    const sinL = Math.sin(libL);
+    const cosL = Math.cos(libL);
+    const sinB = Math.sin(libB);
+    const cosB = Math.cos(libB);
+    const sinPa = Math.sin(pa);
+    const cosPa = Math.cos(pa);
+    const sinPsi = Math.sin(psi);
+    const cosPsi = Math.cos(psi);
+
+    // Orthonormal frame at the sub-observer point: e (toward observer), north tangent, east tangent.
+    // dir is the tangent direction at position angle pa; the surface point is cos(psi)·e + sin(psi)·dir.
+    const dirX = cosPa * (-sinB * cosL) + sinPa * sinL;
+    const dirY = cosPa * (-sinB * sinL) - sinPa * cosL;
+    const dirZ = cosPa * cosB;
+
+    const x = cosPsi * (cosB * cosL) + sinPsi * dirX;
+    const y = cosPsi * (cosB * sinL) + sinPsi * dirY;
+    const z = cosPsi * sinB + sinPsi * dirZ;
+
+    return {
+        lat: Math.asin(z) * RAD,
+        lon: Math.atan2(y, x) * RAD,
+    };
+}


### PR DESCRIPTION
Compute the height of the Moon's visible limb silhouette from LOLA/LDEM terrain data in perspective from the observer's distance. Adds the LunarLimbProfile model, LDEM label parser and limb-height utilities, the ldem_16 dataset, and wires the package into the bundle build.