### PR TITLE
fix(core): use J2000 mean obliquity for J2000 equatorial coordinates

### DIFF
--- a/app/utils/coordinateTransformation.test.ts
+++ b/app/utils/coordinateTransformation.test.ts
@@ -2,6 +2,8 @@ import {
     earthEclipticSpherical2sunEclipticSpherical,
     eclipticJ20002eclipticDate,
     eclipticSpherical2equatorialSpherical,
+    eclipticSpherical2equatorialSphericalByObliquity,
+    eclipticSphericalJ20002equatorialSphericalJ2000,
     equatorialSpherical2eclipticSpherical,
     equatorialSpherical2topocentricHorizontal,
     equatorialSpherical2topocentricSpherical,
@@ -117,6 +119,35 @@ it('tests eclipticSpherical2equatorialSpherical', () => {
     expect(rightAscension).toBeCloseTo(316.174262, 6);
     expect(declination).toBeCloseTo(-18.887468, 6);
     expect(radiusVector).toBeCloseTo(0.910845, 6);
+});
+
+it('tests eclipticSpherical2equatorialSphericalByObliquity', () => {
+    // Meeus example 13.a
+    const coords = {
+        lon: 113.21563,
+        lat: 6.68417,
+        radiusVector: 1,
+    };
+
+    const {rightAscension, declination} = eclipticSpherical2equatorialSphericalByObliquity(coords, 23.4392911);
+
+    expect(rightAscension).toBeCloseTo(116.328942, 5);
+    expect(declination).toBeCloseTo(28.026183, 5);
+});
+
+it('tests eclipticSphericalJ20002equatorialSphericalJ2000 uses the fixed J2000 mean obliquity', () => {
+    // Meeus example 13.a. The J2000 conversion applies the mean obliquity at epoch (23.4392911°),
+    // so it reproduces the reference result regardless of any date.
+    const coords = {
+        lon: 113.21563,
+        lat: 6.68417,
+        radiusVector: 1,
+    };
+
+    const {rightAscension, declination} = eclipticSphericalJ20002equatorialSphericalJ2000(coords);
+
+    expect(rightAscension).toBeCloseTo(116.328942, 5);
+    expect(declination).toBeCloseTo(28.026183, 5);
 });
 
 it('tests equatorialSpherical2eclipticSpherical', () => {

--- a/app/utils/coordinateTransformation.ts
+++ b/app/utils/coordinateTransformation.ts
@@ -152,9 +152,23 @@ export function eclipticSpherical2equatorialSpherical(
     T: number,
     normalize = true,
 ): EquatorialSphericalCoordinates {
+    return eclipticSpherical2equatorialSphericalByObliquity(coords, earth.getTrueObliquityOfEcliptic(T), normalize);
+}
+
+export function eclipticSphericalJ20002equatorialSphericalJ2000(
+    coords: EclipticSphericalCoordinates,
+    normalize = true,
+): EquatorialSphericalCoordinates {
+    return eclipticSpherical2equatorialSphericalByObliquity(coords, earth.getMeanObliquityOfEcliptic(0), normalize);
+}
+
+export function eclipticSpherical2equatorialSphericalByObliquity(
+    coords: EclipticSphericalCoordinates,
+    eps: number,
+    normalize = true,
+): EquatorialSphericalCoordinates {
     const {lon, lat, radiusVector} = coords;
 
-    const eps = earth.getTrueObliquityOfEcliptic(T);
     const epsRad = eps * DEG;
     const lonRad = lon * DEG;
     const latRad = lat * DEG;

--- a/packages/core/models/models/AstronomicalObject.ts
+++ b/packages/core/models/models/AstronomicalObject.ts
@@ -10,6 +10,7 @@ import type {Location} from '@app/types/LocationTypes';
 import {correctEffectOfRefraction} from '@app/utils/apparentPositionCorrections';
 import {
     eclipticSpherical2equatorialSpherical,
+    eclipticSphericalJ20002equatorialSphericalJ2000,
     equatorialSpherical2topocentricHorizontal,
     equatorialSpherical2topocentricSpherical,
     spherical2rectangular,
@@ -67,7 +68,7 @@ export default abstract class AstronomicalObject implements AstronomicalObjectIn
     public getGeocentricEquatorialSphericalJ2000Coordinates(): EquatorialSphericalCoordinates {
         const coords = this.getGeocentricEclipticSphericalJ2000Coordinates();
 
-        return eclipticSpherical2equatorialSpherical(coords, this.Te);
+        return eclipticSphericalJ20002equatorialSphericalJ2000(coords);
     }
 
     public getGeocentricEquatorialSphericalDateCoordinates(): EquatorialSphericalCoordinates {

--- a/packages/moon/models/Moon.test.ts
+++ b/packages/moon/models/Moon.test.ts
@@ -80,8 +80,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = moon.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(134.693283, 6);
-    expect(declination).toBeCloseTo(13.766317, 6);
+    expect(rightAscension).toBeCloseTo(134.693051, 6);
+    expect(declination).toBeCloseTo(13.765362, 6);
     expect(radiusVector).toBeCloseTo(0.002463, 6);
 });
 

--- a/packages/moon/models/MoonHighPrecision.test.ts
+++ b/packages/moon/models/MoonHighPrecision.test.ts
@@ -80,8 +80,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = moon.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(134.693283, 6);
-    expect(declination).toBeCloseTo(13.766317, 6);
+    expect(rightAscension).toBeCloseTo(134.693051, 6);
+    expect(declination).toBeCloseTo(13.765362, 6);
     expect(radiusVector).toBeCloseTo(0.002463, 6);
 });
 

--- a/packages/planets/models/Jupiter.test.ts
+++ b/packages/planets/models/Jupiter.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = jupiter.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(23.8546864866, 8);
-    expect(declination).toBeCloseTo(8.586548163, 8);
+    expect(rightAscension).toBeCloseTo(23.85446539405912, 8);
+    expect(declination).toBeCloseTo(8.587195607911719, 8);
     expect(radiusVector).toBeCloseTo(4.6133801153, 8);
 });
 

--- a/packages/planets/models/JupiterHighPrecision.test.ts
+++ b/packages/planets/models/JupiterHighPrecision.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = jupiter.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(23.8546618792, 8);
-    expect(declination).toBeCloseTo(8.5865615164, 8);
+    expect(rightAscension).toBeCloseTo(23.854440786208922, 8);
+    expect(declination).toBeCloseTo(8.587208960722492, 8);
     expect(radiusVector).toBeCloseTo(4.613385279, 8);
 });
 

--- a/packages/planets/models/Mars.test.ts
+++ b/packages/planets/models/Mars.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = mars.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(330.1569138853, 8);
-    expect(declination).toBeCloseTo(-13.3180595429, 8);
+    expect(rightAscension).toBeCloseTo(330.15724261833446, 8);
+    expect(declination).toBeCloseTo(-13.318856206646522, 8);
     expect(radiusVector).toBeCloseTo(1.8468970949, 8);
 });
 

--- a/packages/planets/models/MarsHighPrecision.test.ts
+++ b/packages/planets/models/MarsHighPrecision.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = mars.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(330.1569117166, 8);
-    expect(declination).toBeCloseTo(-13.3180449041, 8);
+    expect(rightAscension).toBeCloseTo(330.1572404492432, 8);
+    expect(declination).toBeCloseTo(-13.318841567905826, 8);
     expect(radiusVector).toBeCloseTo(1.8468967768, 8);
 });
 

--- a/packages/planets/models/Mercury.test.ts
+++ b/packages/planets/models/Mercury.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = mercury.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(271.2328906479, 8);
-    expect(declination).toBeCloseTo(-24.1483780577, 8);
+    expect(rightAscension).toBeCloseTo(271.2329060920754, 8);
+    expect(declination).toBeCloseTo(-24.14997862255923, 8);
     expect(radiusVector).toBeCloseTo(1.4133093172, 8);
 });
 

--- a/packages/planets/models/MercuryHighPrecision.test.ts
+++ b/packages/planets/models/MercuryHighPrecision.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = mercury.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(271.2387149677, 8);
-    expect(declination).toBeCloseTo(-24.3793371427, 8);
+    expect(rightAscension).toBeCloseTo(271.23873065268145, 8);
+    expect(declination).toBeCloseTo(-24.380937704064042, 8);
     expect(radiusVector).toBeCloseTo(1.4131541144, 8);
 });
 

--- a/packages/planets/models/Neptune.test.ts
+++ b/packages/planets/models/Neptune.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = neptune.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(305.4254342988, 8);
-    expect(declination).toBeCloseTo(-19.2148988934, 8);
+    expect(rightAscension).toBeCloseTo(305.4257577361702, 8);
+    expect(declination).toBeCloseTo(-19.216203446006087, 8);
     expect(radiusVector).toBeCloseTo(31.02103753, 8);
 });
 

--- a/packages/planets/models/NeptuneHighPrecision.test.ts
+++ b/packages/planets/models/NeptuneHighPrecision.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = neptune.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(305.4252849161, 8);
-    expect(declination).toBeCloseTo(-19.2148639596, 8);
+    expect(rightAscension).toBeCloseTo(305.4256083516639, 8);
+    expect(declination).toBeCloseTo(-19.216168514553598, 8);
     expect(radiusVector).toBeCloseTo(31.0210515077, 8);
 });
 

--- a/packages/planets/models/Saturn.test.ts
+++ b/packages/planets/models/Saturn.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = saturn.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(38.7788961425, 8);
-    expect(declination).toBeCloseTo(12.6168300093, 8);
+    expect(rightAscension).toBeCloseTo(38.77861677571883, 8);
+    expect(declination).toBeCloseTo(12.617832698897203, 8);
     expect(radiusVector).toBeCloseTo(8.6455670617, 8);
 });
 

--- a/packages/planets/models/SaturnHighPrecision.test.ts
+++ b/packages/planets/models/SaturnHighPrecision.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = saturn.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(38.7788119846, 8);
-    expect(declination).toBeCloseTo(12.6167928154, 8);
+    expect(rightAscension).toBeCloseTo(38.77853261838213, 8);
+    expect(declination).toBeCloseTo(12.617795503142545, 8);
     expect(radiusVector).toBeCloseTo(8.6455851942, 8);
 });
 

--- a/packages/planets/models/Uranus.test.ts
+++ b/packages/planets/models/Uranus.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = uranus.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(317.4470782918, 8);
-    expect(declination).toBeCloseTo(-16.9930907006, 8);
+    expect(rightAscension).toBeCloseTo(317.44743870803757, 8);
+    expect(declination).toBeCloseTo(-16.994173363010685, 8);
     expect(radiusVector).toBeCloseTo(20.7222657406, 8);
 });
 

--- a/packages/planets/models/UranusHighPrecision.test.ts
+++ b/packages/planets/models/UranusHighPrecision.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = uranus.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(317.4597146784, 8);
-    expect(declination).toBeCloseTo(-17.0248582527, 8);
+    expect(rightAscension).toBeCloseTo(317.46007588288364, 8);
+    expect(declination).toBeCloseTo(-17.025940654901092, 8);
     expect(radiusVector).toBeCloseTo(20.722223336, 8);
 });
 

--- a/packages/planets/models/Venus.test.ts
+++ b/packages/planets/models/Venus.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = venus.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(239.2875763933, 8);
-    expect(declination).toBeCloseTo(-18.3046709183, 8);
+    expect(rightAscension).toBeCloseTo(239.28730589721175, 8);
+    expect(declination).toBeCloseTo(-18.306047307082896, 8);
     expect(radiusVector).toBeCloseTo(1.1344502836, 8);
 });
 

--- a/packages/planets/models/VenusHighPrecision.test.ts
+++ b/packages/planets/models/VenusHighPrecision.test.ts
@@ -79,8 +79,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const {rightAscension, declination, radiusVector} = venus.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(rightAscension).toBeCloseTo(239.2844674862, 8);
-    expect(declination).toBeCloseTo(-18.3162025877, 8);
+    expect(rightAscension).toBeCloseTo(239.2841967828536, 8);
+    expect(declination).toBeCloseTo(-18.317578932101004, 8);
     expect(radiusVector).toBeCloseTo(1.1344481893, 8);
 });
 

--- a/packages/sun/models/Sun.test.ts
+++ b/packages/sun/models/Sun.test.ts
@@ -80,8 +80,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const coords = sun.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(coords.rightAscension).toBeCloseTo(206.981838961, 8);
-    expect(coords.declination).toBeCloseTo(-11.1256268442, 8);
+    expect(coords.rightAscension).toBeCloseTo(206.98143606879967, 8);
+    expect(coords.declination).toBeCloseTo(-11.126669836063416, 8);
     expect(coords.radiusVector).toBeCloseTo(0.9951454386, 8);
 });
 

--- a/packages/sun/models/SunHighPrecision.test.ts
+++ b/packages/sun/models/SunHighPrecision.test.ts
@@ -84,8 +84,8 @@ it('tests getGeocentricEclipticSphericalDateCoordinates', () => {
 it('tests getGeocentricEquatorialSphericalJ2000Coordinates', () => {
     const coords = sun.getGeocentricEquatorialSphericalJ2000Coordinates();
 
-    expect(coords.rightAscension).toBeCloseTo(206.9818265112, 8);
-    expect(coords.declination).toBeCloseTo(-11.1256928896, 8);
+    expect(coords.rightAscension).toBeCloseTo(206.98142361646916, 8);
+    expect(coords.declination).toBeCloseTo(-11.12673588100559, 8);
     expect(coords.radiusVector).toBeCloseTo(0.9951436361, 8);
 });
 


### PR DESCRIPTION
getGeocentricEquatorialSphericalJ2000Coordinates converted J2000 ecliptic coordinates using the true obliquity at the date (this.Te), which mixed a J2000 frame with a date-dependent, nutation-corrected obliquity.

Convert J2000 ecliptic to J2000 equatorial using the mean obliquity at the J2000 epoch instead. Extract eclipticSpherical2equatorialSphericalByObliquity as a shared helper and add eclipticSphericalJ20002equatorialSphericalJ2000.