### PR TITLE
feat(solar-eclipse): add sunrise/sunset boundary polygons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,12 @@
+# Instructions for AI agents
+
 * Ignore the `/old` folder
-* Add unit tests for all added or changed logic
 * Order functions within a file hierarchically, like a book's table of contents: public entry points first, then the helpers they call, drilling down so a caller always appears before its callees. Do not prefix function names with underscores.
 * Avoid extensive comments. The code should be self-explanatory.
+
+## General instructions
+
+* Add unit tests for all added or changed logic
+* Run `yarn lint:fix` and `yarn check:typescript` after every task. Ensure everything is working.
+* All types belong into a dedicated file in the `types` folder.
+* Order functions hierarchically like a TOC of a book.

--- a/packages/lunarEclipse/README.md
+++ b/packages/lunarEclipse/README.md
@@ -2,7 +2,7 @@ Part of the [Astronomy Bundle](../../README.md).
 
 # Lunar Eclipse
 
-The `lunarEclipse` package provides lunar eclipse Besselian elements for any eclipse between 2000 BCE and 3000 CE. The elements — computed by Fred Espenak and Jean Meeus — are pre-computed polynomial coefficients describing the Moon's position relative to Earth's shadow, together with eclipse type, magnitudes, and contact times.
+The `lunarEclipse` package provides lunar eclipse Besselian elements for any eclipse between 2000 BCE and 3000 CE. The elements are pre-computed polynomial coefficients describing the Moon's position relative to Earth's shadow, together with eclipse type, magnitudes, and contact times.
 
 ## Contents
 

--- a/packages/solarEclipse/README.md
+++ b/packages/solarEclipse/README.md
@@ -28,6 +28,7 @@ The `solarEclipse` package provides solar eclipse calculations for any location 
       - [Central line](#central-line)
       - [Umbra path polygon](#umbra-path-polygon)
       - [Penumbra path polygon](#penumbra-path-polygon)
+      - [Sunrise / sunset boundary polygons](#sunrise--sunset-boundary-polygons)
     - [Local eclipse for an observer](#local-eclipse-for-an-observer)
   - [LocalSolarEclipse (Eclipse + Location)](#localsolareclipse-eclipse--location)
     - [Local eclipse type](#local-eclipse-type)
@@ -273,9 +274,9 @@ The result of the calculation should be: *272.8*
 
 #### Shadow geometry
 
-**Description:** The following three methods trace the Moon's shadow across Earth's surface: the central line, the umbra (path of totality/annularity), and the penumbra (region of partial visibility). They all accept the same optional `ShadowPathOptions` object:
+**Description:** The following methods trace the Moon's shadow across Earth's surface: the central line, the umbra (path of totality/annularity), the penumbra (region of partial visibility), and the sunrise/sunset boundary loops. They all accept the same optional `ShadowPathOptions` object:
 
-- `stepsInSeconds` (default: `10`) — the time resolution in seconds between sampled points; smaller values produce a denser, more precise path.
+- `stepsInSeconds` (default: `10`) — the time resolution in seconds between sampled points; smaller values produce a denser, more precise path. Ignored by the sunrise/sunset boundary polygons, which use a fixed internal resolution.
 - `refraction` (default: `false`) — the horizon convention used for the endpoints. When `false`, the geometric horizon (Sun altitude 0°) is used. When `true`, the standard rise/set horizon (−50′, i.e. 34′ atmospheric refraction plus the Sun's 16′ semidiameter) is used, so the path reaches slightly further to where the Sun is still visible at the horizon.
 
 ##### Central line
@@ -307,6 +308,16 @@ Returns the region of the partial eclipse as a single closed polygon — the are
 
 ```javascript
 const polygon = eclipse.getPenumbraPathPolygon();
+// [{lat: ..., lon: ...}, ..., {lat: ..., lon: ...}] — first point equals last
+```
+
+##### Sunrise / sunset boundary polygons
+
+Return the rise/set boundary curves shown on Jubier/Espenak maps — the closed loops enclosing the region where the eclipse is already in progress as the Sun rises or sets. `getSunriseBoundaryPolygon` traces the sunrise side, `getSunsetBoundaryPolygon` the sunset side. Each result is an array of `{lat, lon}` coordinate objects in decimal degrees whose first and last points are identical, so the ring is closed. Only the `refraction` option applies here; `stepsInSeconds` is ignored. For an eclipse whose penumbra never fully leaves the day/night terminator both halves form a single loop, which is returned on one side while the other side is an empty array.
+
+```javascript
+const sunrisePolygon = eclipse.getSunriseBoundaryPolygon();
+const sunsetPolygon = eclipse.getSunsetBoundaryPolygon();
 // [{lat: ..., lon: ...}, ..., {lat: ..., lon: ...}] — first point equals last
 ```
 

--- a/packages/solarEclipse/README.md
+++ b/packages/solarEclipse/README.md
@@ -313,7 +313,7 @@ const polygon = eclipse.getPenumbraPathPolygon();
 
 ##### Sunrise / sunset boundary polygons
 
-Return the rise/set boundary curves shown on Jubier/Espenak maps — the closed loops enclosing the region where the eclipse is already in progress as the Sun rises or sets. `getSunriseBoundaryPolygon` traces the sunrise side, `getSunsetBoundaryPolygon` the sunset side. Each result is an array of `{lat, lon}` coordinate objects in decimal degrees whose first and last points are identical, so the ring is closed. Only the `refraction` option applies here; `stepsInSeconds` is ignored. For an eclipse whose penumbra never fully leaves the day/night terminator both halves form a single loop, which is returned on one side while the other side is an empty array.
+Return the rise/set boundary curves shown on eclipse maps — the closed loops enclosing the region where the eclipse is already in progress as the Sun rises or sets. `getSunriseBoundaryPolygon` traces the sunrise side, `getSunsetBoundaryPolygon` the sunset side. Each result is an array of `{lat, lon}` coordinate objects in decimal degrees whose first and last points are identical, so the ring is closed. Only the `refraction` option applies here; `stepsInSeconds` is ignored. For an eclipse whose penumbra never fully leaves the day/night terminator both halves form a single loop, which is returned on one side while the other side is an empty array.
 
 ```javascript
 const sunrisePolygon = eclipse.getSunriseBoundaryPolygon();

--- a/packages/solarEclipse/models/SolarEclipse.test.ts
+++ b/packages/solarEclipse/models/SolarEclipse.test.ts
@@ -115,6 +115,22 @@ describe('getPenumbraPathPolygon', () => {
     });
 });
 
+describe('getSunsetBoundaryPolygon', () => {
+    it('returns a closed loop around the region seeing the eclipse at sunset', () => {
+        const polygon = eclipse.getSunsetBoundaryPolygon();
+
+        expect(polygon[0]).toEqual(polygon[polygon.length - 1]);
+        expect(isPointInPolygon({lat: -33.447, lon: -70.673}, polygon)).toBe(true);
+        expect(isPointInPolygon({lat: 40.7128, lon: -74.006}, polygon)).toBe(false);
+    });
+});
+
+describe('getSunriseBoundaryPolygon', () => {
+    it('is empty when a single rise/set run covers both halves', () => {
+        expect(eclipse.getSunriseBoundaryPolygon()).toEqual([]);
+    });
+});
+
 describe('getCenterLine', () => {
     it('returns the central line with default 10 sec steps', () => {
         const result = eclipse.getCentralLine();

--- a/packages/solarEclipse/models/SolarEclipse.ts
+++ b/packages/solarEclipse/models/SolarEclipse.ts
@@ -1,7 +1,12 @@
 import type {LatLon, Location} from '@app/types/LocationTypes';
 import type {ShadowPathOptions} from '@package/solarEclipse/services/shadowGeometry/types/ShadowPathTypes';
 import {getCentralLine} from '@package/solarEclipse/services/shadowGeometry/utils/centralLine';
+import {horizonSinAltitude} from '@package/solarEclipse/services/shadowGeometry/utils/constants';
 import calculatePenumbraPathPolygon from '@package/solarEclipse/services/shadowGeometry/utils/penumbraPathPolygon';
+import {
+    calculateSunriseBoundary,
+    calculateSunsetBoundary,
+} from '@package/solarEclipse/services/shadowGeometry/utils/riseSetBoundary';
 import calculateUmbraPathPolygon from '@package/solarEclipse/services/shadowGeometry/utils/umbraPathPolygon';
 import type {LocalEclipseCircumstances} from '@package/solarEclipse/types/EclipseCircumstances';
 import {getCentralDuration, getDuration} from '@package/solarEclipse/utils/duration';
@@ -111,5 +116,13 @@ export default class SolarEclipse {
 
     public getPenumbraPathPolygon(options: ShadowPathOptions = {}): Array<LatLon> {
         return calculatePenumbraPathPolygon(this.elements, options);
+    }
+
+    public getSunriseBoundaryPolygon(options: ShadowPathOptions = {}): Array<LatLon> {
+        return calculateSunriseBoundary(this.elements, horizonSinAltitude(options));
+    }
+
+    public getSunsetBoundaryPolygon(options: ShadowPathOptions = {}): Array<LatLon> {
+        return calculateSunsetBoundary(this.elements, horizonSinAltitude(options));
     }
 }

--- a/packages/solarEclipse/services/shadowGeometry/utils/constants.ts
+++ b/packages/solarEclipse/services/shadowGeometry/utils/constants.ts
@@ -19,3 +19,9 @@ export function horizonSinAltitude(settings?: {refraction?: boolean}): number {
 
 export const CENTRAL_LINE_STEP_HOURS = 1 / (60 * 60);
 export const UMBRA_REGION_STEP_HOURS = 1 / 720;
+
+export const RISE_SET_BOUNDARY_STEP_HOURS = 1 / 60;
+export const RISE_SET_BOUNDARY_Q_SAMPLES = 180;
+export const RISE_SET_TIP_REFINEMENT_SAMPLES = 16;
+export const RISE_SET_MAX_CHORD_DEG = 0.75;
+export const RISE_SET_GAP_SUBDIVISION_DEPTH = 5;

--- a/packages/solarEclipse/services/shadowGeometry/utils/riseSetBoundary.test.ts
+++ b/packages/solarEclipse/services/shadowGeometry/utils/riseSetBoundary.test.ts
@@ -1,0 +1,44 @@
+import {horizonSinAltitude} from './constants';
+import isPointInPolygon from './pointInPolygon';
+import {calculateSunriseBoundary, calculateSunsetBoundary} from './riseSetBoundary';
+import {ELEMENTS_2019_07_02, ELEMENTS_2021_12_04} from './testSupport';
+
+describe('2019-07-02 (South Pacific / Chile / Argentina)', () => {
+    const sunset = calculateSunsetBoundary(ELEMENTS_2019_07_02, 0);
+
+    it('traces one closed loop for the sunset boundary', () => {
+        expect(sunset.length).toBeGreaterThan(100);
+        expect(sunset[0]).toEqual(sunset[sunset.length - 1]);
+    });
+
+    it('encloses regions where the eclipse is in progress at sunset', () => {
+        expect(isPointInPolygon({lat: -33.447, lon: -70.673}, sunset)).toBe(true);
+        expect(isPointInPolygon({lat: -34.6037, lon: -58.3816}, sunset)).toBe(true);
+    });
+
+    it('excludes regions far from the terminator', () => {
+        expect(isPointInPolygon({lat: 40.7128, lon: -74.006}, sunset)).toBe(false);
+        expect(isPointInPolygon({lat: -20, lon: -140}, sunset)).toBe(false);
+    });
+
+    it('keeps the sunrise side empty when a single run covers both halves', () => {
+        expect(calculateSunriseBoundary(ELEMENTS_2019_07_02, 0)).toEqual([]);
+    });
+
+    it('depends on the horizon convention', () => {
+        const refracted = calculateSunsetBoundary(ELEMENTS_2019_07_02, horizonSinAltitude({refraction: true}));
+
+        expect(refracted.length).toBeGreaterThan(100);
+        expect(refracted).not.toEqual(sunset);
+    });
+});
+
+describe('2021-12-04 (Antarctica)', () => {
+    it('traces one closed loop for the sunrise boundary', () => {
+        const sunrise = calculateSunriseBoundary(ELEMENTS_2021_12_04, 0);
+
+        expect(sunrise.length).toBeGreaterThan(100);
+        expect(sunrise[0]).toEqual(sunrise[sunrise.length - 1]);
+        expect(calculateSunsetBoundary(ELEMENTS_2021_12_04, 0)).toEqual([]);
+    });
+});

--- a/packages/solarEclipse/services/shadowGeometry/utils/riseSetBoundary.ts
+++ b/packages/solarEclipse/services/shadowGeometry/utils/riseSetBoundary.ts
@@ -1,0 +1,485 @@
+import type {LatLon} from '@app/types/LocationTypes';
+import {polynomialDerivative} from '@app/utils/polynoms';
+import type {BesselianElements, BesselianElementsAtTime} from '@package/solarEclipse/types/BesselianElementTypes';
+import {getBesselianElementsAtTime, getEclipseDeltaT} from '@package/solarEclipse/utils/besselianElements';
+import {
+    DEG,
+    E_SQ,
+    ONE_MINUS_F,
+    RISE_SET_BOUNDARY_Q_SAMPLES,
+    RISE_SET_BOUNDARY_STEP_HOURS,
+    RISE_SET_GAP_SUBDIVISION_DEPTH,
+    RISE_SET_MAX_CHORD_DEG,
+    RISE_SET_TIP_REFINEMENT_SAMPLES,
+} from './constants';
+import {isOnSunsetSide} from './maxEclipseHorizon';
+import {calculateShadowBoundaryPoint, penumbraBoundaryFundamental} from './shadowBoundary';
+import {terminatorRingPoint} from './shadowOutline';
+
+export function calculateSunriseBoundary(elements: BesselianElements, z0: number): Array<LatLon> {
+    return calculateRiseSetBoundary(elements, false, z0);
+}
+
+export function calculateSunsetBoundary(elements: BesselianElements, z0: number): Array<LatLon> {
+    return calculateRiseSetBoundary(elements, true, z0);
+}
+
+export function calculateRiseSetBoundary(elements: BesselianElements, isSunset: boolean, z0: number): Array<LatLon> {
+    let best: Array<LatLon> = [];
+    for (const run of calculateRiseSetRuns(elements, z0)) {
+        const cycle = assembleRunCycle(run);
+        const sunsetCount = cycle.filter((p) => p.isSunset).length;
+        const runIsSunset = sunsetCount * 2 > cycle.length;
+        if (runIsSunset === isSunset && cycle.length > best.length) {
+            best = cycle.map((p) => p.point);
+        }
+    }
+    if (best.length > 0) {
+        best.push({...best[0]});
+    }
+
+    return best;
+}
+
+interface SidedPoint {
+    point: LatLon;
+    isSunset: boolean;
+}
+
+interface RiseSetRun {
+    leadingEdge: Array<SidedPoint>;
+    trailingEdge: Array<SidedPoint>;
+    startTip: SidedPoint | null;
+    endTip: SidedPoint | null;
+}
+
+function calculateRiseSetRuns(elements: BesselianElements, z0: number): Array<RiseSetRun> {
+    const deltaT = getEclipseDeltaT(elements);
+    const runs: Array<RiseSetRun> = [];
+    let current: RiseSetRun | null = null;
+
+    let prevCount = 0;
+    let lastSingleBranch: 'leading' | 'trailing' | null = null;
+
+    const feed = (crossings: Array<TerminatorCrossing>): void => {
+        if (current === null || crossings.length === 0) {
+            return;
+        }
+        const {leadingEdge, trailingEdge} = current;
+        const leadingLast = leadingEdge.length > 0 ? leadingEdge[leadingEdge.length - 1].point : null;
+        const trailingLast = trailingEdge.length > 0 ? trailingEdge[trailingEdge.length - 1].point : null;
+
+        if (crossings.length >= 2) {
+            const c0 = {point: crossings[0].point, isSunset: crossings[0].isSunset};
+            const c1 = {point: crossings[1].point, isSunset: crossings[1].isSunset};
+            if (leadingLast === null && trailingLast === null) {
+                if (crossings[0].qCos >= crossings[1].qCos) {
+                    leadingEdge.push(c0);
+                    trailingEdge.push(c1);
+                } else {
+                    leadingEdge.push(c1);
+                    trailingEdge.push(c0);
+                }
+            } else if (leadingLast !== null && trailingLast !== null) {
+                const dLL0 = latLonDistSq(c0.point, leadingLast);
+                const dLL1 = latLonDistSq(c1.point, leadingLast);
+                const dTL0 = latLonDistSq(c0.point, trailingLast);
+                const dTL1 = latLonDistSq(c1.point, trailingLast);
+                if (dLL0 + dTL1 <= dLL1 + dTL0) {
+                    leadingEdge.push(c0);
+                    trailingEdge.push(c1);
+                } else {
+                    leadingEdge.push(c1);
+                    trailingEdge.push(c0);
+                }
+            } else if (leadingLast !== null) {
+                // Trailing branch hasn't started yet — continue leading with the closer
+                // crossing, fork the other into a fresh trailing branch.
+                if (latLonDistSq(c0.point, leadingLast) <= latLonDistSq(c1.point, leadingLast)) {
+                    leadingEdge.push(c0);
+                    trailingEdge.push(c1);
+                } else {
+                    leadingEdge.push(c1);
+                    trailingEdge.push(c0);
+                }
+            } else {
+                // Mirror of the previous case.
+                if (latLonDistSq(c0.point, trailingLast as LatLon) <= latLonDistSq(c1.point, trailingLast as LatLon)) {
+                    trailingEdge.push(c0);
+                    leadingEdge.push(c1);
+                } else {
+                    trailingEdge.push(c1);
+                    leadingEdge.push(c0);
+                }
+            }
+            lastSingleBranch = null;
+        } else {
+            const c = crossings[0];
+            let target: 'leading' | 'trailing';
+            if (lastSingleBranch !== null) {
+                target = lastSingleBranch;
+            } else if (leadingLast !== null && trailingLast !== null) {
+                target =
+                    latLonDistSq(c.point, leadingLast) <= latLonDistSq(c.point, trailingLast) ? 'leading' : 'trailing';
+            } else if (leadingLast !== null) {
+                target = 'leading';
+            } else if (trailingLast !== null) {
+                target = 'trailing';
+            } else {
+                target = c.qCos >= 0 ? 'leading' : 'trailing';
+            }
+            if (target === 'leading') {
+                leadingEdge.push({point: c.point, isSunset: c.isSunset});
+            } else {
+                trailingEdge.push({point: c.point, isSunset: c.isSunset});
+            }
+            lastSingleBranch = target;
+        }
+    };
+
+    const feedTipNeighborhood = (tangentTau: number, gridTau: number): void => {
+        const span = gridTau - tangentTau;
+        const N = RISE_SET_TIP_REFINEMENT_SAMPLES;
+        for (let i = 1; i < N; i++) {
+            const k = span > 0 ? i : N - i;
+            feed(crossingsAtTau(elements, tangentTau + span * (k / N) ** 2, z0, deltaT));
+        }
+    };
+
+    const needsSubdivision = (crossings: Array<TerminatorCrossing>): boolean => {
+        if (current === null) {
+            return false;
+        }
+        const ends: Array<LatLon> = [];
+        if (current.leadingEdge.length > 0) {
+            ends.push(current.leadingEdge[current.leadingEdge.length - 1].point);
+        }
+        if (current.trailingEdge.length > 0) {
+            ends.push(current.trailingEdge[current.trailingEdge.length - 1].point);
+        }
+        if (ends.length === 0) {
+            return false;
+        }
+
+        return crossings.some((c) =>
+            ends.every((end) => {
+                let dLon = Math.abs(c.point.lon - end.lon);
+                if (dLon > 180) {
+                    dLon = 360 - dLon;
+                }
+                dLon *= Math.cos(((c.point.lat + end.lat) / 2) * DEG);
+                const dLat = c.point.lat - end.lat;
+
+                return dLat * dLat + dLon * dLon > RISE_SET_MAX_CHORD_DEG ** 2;
+            }),
+        );
+    };
+
+    const feedRefined = (tauA: number, tauB: number, crossingsB: Array<TerminatorCrossing>, depth: number): void => {
+        if (depth > 0 && needsSubdivision(crossingsB)) {
+            const mid = (tauA + tauB) / 2;
+            feedRefined(tauA, mid, crossingsAtTau(elements, mid, z0, deltaT), depth - 1);
+            feedRefined(mid, tauB, crossingsB, depth - 1);
+
+            return;
+        }
+        feed(crossingsB);
+    };
+
+    for (let tau = elements.tMin; tau <= elements.tMax; tau += RISE_SET_BOUNDARY_STEP_HOURS) {
+        const crossings = crossingsAtTau(elements, tau, z0, deltaT);
+
+        if (crossings.length === 0) {
+            if (current !== null) {
+                // Close the run; a 2 → 0 transition is a true tangent, 1 → 0 is not.
+                if (prevCount >= 2) {
+                    const tangent = bisectEndTangent(elements, tau - RISE_SET_BOUNDARY_STEP_HOURS, tau, z0, deltaT);
+                    if (tangent !== null) {
+                        feedTipNeighborhood(tangent.tau, tau - RISE_SET_BOUNDARY_STEP_HOURS);
+                        current.endTip = tangent.tip;
+                    }
+                }
+                runs.push(current);
+                current = null;
+            }
+            lastSingleBranch = null;
+            prevCount = 0;
+            continue;
+        }
+
+        if (current === null) {
+            current = {leadingEdge: [], trailingEdge: [], startTip: null, endTip: null};
+            lastSingleBranch = null;
+            // A 0 → 2 transition is a true tangent; skip when the sweep starts mid-run at tMin.
+            if (crossings.length >= 2 && tau > elements.tMin) {
+                const tangent = bisectEndTangent(elements, tau, tau - RISE_SET_BOUNDARY_STEP_HOURS, z0, deltaT);
+                if (tangent !== null) {
+                    current.startTip = tangent.tip;
+                    feedTipNeighborhood(tangent.tau, tau);
+                }
+            }
+        }
+
+        feedRefined(tau - RISE_SET_BOUNDARY_STEP_HOURS, tau, crossings, RISE_SET_GAP_SUBDIVISION_DEPTH);
+        prevCount = crossings.length;
+    }
+    if (current !== null) {
+        runs.push(current);
+    }
+
+    return runs;
+}
+
+function assembleRunCycle(run: RiseSetRun): Array<SidedPoint> {
+    const cycle: Array<SidedPoint> = [];
+    if (run.startTip !== null) {
+        cycle.push(run.startTip);
+    }
+    cycle.push(...run.leadingEdge);
+    if (run.endTip !== null) {
+        cycle.push(run.endTip);
+    }
+    for (let i = run.trailingEdge.length - 1; i >= 0; i--) {
+        cycle.push(run.trailingEdge[i]);
+    }
+
+    return cycle;
+}
+
+interface TerminatorCrossing {
+    point: LatLon;
+    qCos: number;
+    isSunset: boolean;
+}
+
+function bisectEndTangent(
+    elements: BesselianElements,
+    tauWithTwo: number,
+    tauWithLess: number,
+    z0: number,
+    deltaT: number,
+): {tip: SidedPoint; tau: number} | null {
+    let twoSide = tauWithTwo;
+    let lessSide = tauWithLess;
+    for (let iter = 0; iter < 40; iter++) {
+        const mid = (twoSide + lessSide) / 2;
+        const c = crossingsAtTau(elements, mid, z0, deltaT);
+        if (c.length >= 2) {
+            twoSide = mid;
+        } else {
+            lessSide = mid;
+        }
+        if (Math.abs(lessSide - twoSide) < 1e-8) {
+            break;
+        }
+    }
+    const c = crossingsAtTau(elements, twoSide, z0, deltaT);
+    if (c.length === 0) {
+        return null;
+    }
+    if (c.length === 1) {
+        return {tip: {point: c[0].point, isSunset: c[0].isSunset}, tau: twoSide};
+    }
+
+    const e = getBesselianElementsAtTime(elements, twoSide);
+    const tangencyPoint = refineTangentToHorizon(elements, e, z0);
+    if (tangencyPoint !== null) {
+        return {tip: {point: tangencyPoint, isSunset: c[0].isSunset}, tau: twoSide};
+    }
+
+    const dlon = ((c[1].point.lon - c[0].point.lon + 540) % 360) - 180;
+    let avgLon = c[0].point.lon + dlon / 2;
+    while (avgLon > 180) {
+        avgLon -= 360;
+    }
+    while (avgLon < -180) {
+        avgLon += 360;
+    }
+
+    return {
+        tip: {point: {lat: (c[0].point.lat + c[1].point.lat) / 2, lon: avgLon}, isSunset: c[0].isSunset},
+        tau: twoSide,
+    };
+}
+
+function crossingsAtTau(elements: BesselianElements, tau: number, z0: number, deltaT: number): Array<TerminatorCrossing> {
+    const e = getBesselianElementsAtTime(elements, tau);
+    const dx = polynomialDerivative(elements.x, tau);
+    const dy = polynomialDerivative(elements.y, tau);
+    const qVelocity = Math.atan2(dy, dx);
+
+    return collectCrossings(elements, e, qVelocity, z0, deltaT);
+}
+
+function collectCrossings(
+    elements: BesselianElements,
+    e: BesselianElementsAtTime,
+    qVelocity: number,
+    z0: number,
+    deltaT: number,
+): Array<TerminatorCrossing> {
+    const N = RISE_SET_BOUNDARY_Q_SAMPLES;
+    const pts: Array<LatLon | null> = new Array(N);
+    for (let i = 0; i < N; i++) {
+        pts[i] = calculateShadowBoundaryPoint(elements, e, (i / N) * 2 * Math.PI, false);
+    }
+
+    const result: Array<TerminatorCrossing> = [];
+    for (let i = 0; i < N; i++) {
+        const j = (i + 1) % N;
+        const p1 = pts[i];
+        const p2 = pts[j];
+        if ((p1 === null) === (p2 === null)) {
+            continue;
+        }
+
+        const q1 = (i / N) * 2 * Math.PI;
+        const q2 = ((i + 1) / N) * 2 * Math.PI;
+        const crossing = p1 !== null ? findNullBoundary(elements, e, q1, q2) : findNullBoundary(elements, e, q2, q1);
+        if (crossing === null) {
+            continue;
+        }
+
+        const point = refineCrossingToHorizon(elements, e, crossing.xi, crossing.eta, z0) ?? crossing.geometric;
+        const qCrossing = (q1 + q2) / 2;
+        result.push({
+            point,
+            qCos: Math.cos(qCrossing - qVelocity),
+            isSunset: isOnSunsetSide(crossing.geometric, e, deltaT),
+        });
+    }
+
+    return result;
+}
+
+function findNullBoundary(
+    elements: BesselianElements,
+    e: BesselianElementsAtTime,
+    qNonNull: number,
+    qNull: number,
+): {geometric: LatLon; xi: number; eta: number} | null {
+    let nonNullSide = qNonNull;
+    let nullSide = qNull;
+
+    for (let iter = 0; iter < 50; iter++) {
+        const qMid = (nonNullSide + nullSide) / 2;
+        const p = calculateShadowBoundaryPoint(elements, e, qMid, false);
+        if (p !== null) {
+            nonNullSide = qMid;
+        } else {
+            nullSide = qMid;
+        }
+        if (Math.abs(nullSide - nonNullSide) < 1e-9) {
+            break;
+        }
+    }
+
+    const geometric = calculateShadowBoundaryPoint(elements, e, nonNullSide, false);
+    const fundamental = penumbraBoundaryFundamental(elements, e, nonNullSide);
+    if (geometric === null || fundamental === null) {
+        return null;
+    }
+
+    return {geometric, xi: fundamental.xi, eta: fundamental.eta};
+}
+
+function refineCrossingToHorizon(
+    elements: BesselianElements,
+    e: BesselianElementsAtTime,
+    xiSeed: number,
+    etaSeed: number,
+    z0: number,
+): LatLon | null {
+    const penumbraRadius = Math.abs(e.l1 - z0 * elements.tanF1);
+    const axisDistance = Math.hypot(e.x, e.y);
+    if (axisDistance === 0) {
+        return null;
+    }
+    const ux = e.x / axisDistance;
+    const uy = e.y / axisDistance;
+
+    let xi = xiSeed;
+    let eta = etaSeed;
+    // On the ring sinU follows linearly from eta: (1 - f) sinU = eta cos d + zeta sin d.
+    let sinU = (etaSeed * e.cosD + z0 * e.sinD) / ONE_MINUS_F;
+    for (let iter = 0; iter < 40; iter++) {
+        // Radius (about the axis) of the terminator ring at zeta = z0 on the ellipsoid.
+        const ringRadiusSq = 1 - E_SQ * sinU * sinU - z0 * z0;
+        if (ringRadiusSq < 0) {
+            return null;
+        }
+        const ringRadius = Math.sqrt(ringRadiusSq);
+        const along =
+            (ringRadius * ringRadius - penumbraRadius * penumbraRadius + axisDistance * axisDistance)
+            / (2 * axisDistance);
+        const halfChordSq = ringRadius * ringRadius - along * along;
+        if (halfChordSq < 0) {
+            return null;
+        }
+        const halfChord = Math.sqrt(halfChordSq);
+        const baseXi = along * ux;
+        const baseEta = along * uy;
+        const candidate1Xi = baseXi - halfChord * uy;
+        const candidate1Eta = baseEta + halfChord * ux;
+        const candidate2Xi = baseXi + halfChord * uy;
+        const candidate2Eta = baseEta - halfChord * ux;
+        const dist1 = (candidate1Xi - xi) ** 2 + (candidate1Eta - eta) ** 2;
+        const dist2 = (candidate2Xi - xi) ** 2 + (candidate2Eta - eta) ** 2;
+        const nextXi = dist1 <= dist2 ? candidate1Xi : candidate2Xi;
+        const nextEta = dist1 <= dist2 ? candidate1Eta : candidate2Eta;
+        const moved = (nextXi - xi) ** 2 + (nextEta - eta) ** 2;
+        xi = nextXi;
+        eta = nextEta;
+        sinU = (eta * e.cosD + z0 * e.sinD) / ONE_MINUS_F;
+        if (moved < 1e-18) {
+            break;
+        }
+    }
+
+    return terminatorRingPoint(elements, e, Math.atan2(eta, xi), sinU, z0).point;
+}
+
+function refineTangentToHorizon(elements: BesselianElements, e: BesselianElementsAtTime, z0: number): LatLon | null {
+    const penumbraRadius = Math.abs(e.l1 - z0 * elements.tanF1);
+    const axisDistance = Math.hypot(e.x, e.y);
+    if (axisDistance === 0) {
+        return null;
+    }
+    const ux = e.x / axisDistance;
+    const uy = e.y / axisDistance;
+
+    let xi = ux;
+    let eta = uy;
+    let sinU = (uy * e.cosD + z0 * e.sinD) / ONE_MINUS_F;
+    for (let iter = 0; iter < 40; iter++) {
+        const ringRadiusSq = 1 - E_SQ * sinU * sinU - z0 * z0;
+        if (ringRadiusSq < 0) {
+            return null;
+        }
+        const along =
+            (ringRadiusSq - penumbraRadius * penumbraRadius + axisDistance * axisDistance) / (2 * axisDistance);
+        xi = along * ux;
+        eta = along * uy;
+        const next = (eta * e.cosD + z0 * e.sinD) / ONE_MINUS_F;
+        const moved = (next - sinU) ** 2;
+        sinU = next;
+        if (moved < 1e-18) {
+            break;
+        }
+    }
+
+    return terminatorRingPoint(elements, e, Math.atan2(eta, xi), sinU, z0).point;
+}
+
+function latLonDistSq(a: LatLon, b: LatLon): number {
+    let dLon = b.lon - a.lon;
+    while (dLon > 180) {
+        dLon -= 360;
+    }
+    while (dLon < -180) {
+        dLon += 360;
+    }
+    const dLat = b.lat - a.lat;
+
+    return dLat * dLat + dLon * dLon;
+}

--- a/packages/solarEclipse/services/shadowGeometry/utils/riseSetBoundary.ts
+++ b/packages/solarEclipse/services/shadowGeometry/utils/riseSetBoundary.ts
@@ -302,7 +302,12 @@ function bisectEndTangent(
     };
 }
 
-function crossingsAtTau(elements: BesselianElements, tau: number, z0: number, deltaT: number): Array<TerminatorCrossing> {
+function crossingsAtTau(
+    elements: BesselianElements,
+    tau: number,
+    z0: number,
+    deltaT: number,
+): Array<TerminatorCrossing> {
     const e = getBesselianElementsAtTime(elements, tau);
     const dx = polynomialDerivative(elements.x, tau);
     const dy = polynomialDerivative(elements.y, tau);

--- a/packages/solarEclipse/services/shadowGeometry/utils/shadowBoundary.test.ts
+++ b/packages/solarEclipse/services/shadowGeometry/utils/shadowBoundary.test.ts
@@ -18,7 +18,10 @@ describe('penumbraBoundaryFundamental', () => {
             if (solution === null) {
                 continue;
             }
-            const axisDistance = Math.hypot(fundamental.xi - atGreatestEclipse.x, fundamental.eta - atGreatestEclipse.y);
+            const axisDistance = Math.hypot(
+                fundamental.xi - atGreatestEclipse.x,
+                fundamental.eta - atGreatestEclipse.y,
+            );
             const penumbraRadius = Math.abs(atGreatestEclipse.l1 - solution.zeta * elements.tanF1);
             expect(axisDistance).toBeCloseTo(penumbraRadius, 6);
             checked++;

--- a/packages/solarEclipse/services/shadowGeometry/utils/shadowBoundary.test.ts
+++ b/packages/solarEclipse/services/shadowGeometry/utils/shadowBoundary.test.ts
@@ -1,0 +1,71 @@
+import {getBesselianElementsAtTime} from '@package/solarEclipse/utils/besselianElements';
+import {calculateShadowBoundaryPoint, penumbraBoundaryFundamental} from './shadowBoundary';
+import {fundamentalToLatLon, solveSurfacePoint} from './surface';
+import {ELEMENTS_2019_07_02 as elements} from './testSupport';
+
+const atGreatestEclipse = getBesselianElementsAtTime(elements, 0);
+const offEarth = getBesselianElementsAtTime(elements, 2.8);
+
+describe('penumbraBoundaryFundamental', () => {
+    it('lands on the penumbral limit at its own zeta', () => {
+        let checked = 0;
+        for (let q = 0; q < 2 * Math.PI; q += Math.PI / 8) {
+            const fundamental = penumbraBoundaryFundamental(elements, atGreatestEclipse, q);
+            if (fundamental === null) {
+                continue;
+            }
+            const solution = solveSurfacePoint(elements, atGreatestEclipse, fundamental.xi, fundamental.eta, false);
+            if (solution === null) {
+                continue;
+            }
+            const axisDistance = Math.hypot(fundamental.xi - atGreatestEclipse.x, fundamental.eta - atGreatestEclipse.y);
+            const penumbraRadius = Math.abs(atGreatestEclipse.l1 - solution.zeta * elements.tanF1);
+            expect(axisDistance).toBeCloseTo(penumbraRadius, 6);
+            checked++;
+        }
+        expect(checked).toBeGreaterThan(0);
+    });
+});
+
+describe('calculateShadowBoundaryPoint', () => {
+    it('agrees with the converged fundamental-plane coordinates', () => {
+        let checked = 0;
+        for (let q = 0; q < 2 * Math.PI; q += Math.PI / 8) {
+            const point = calculateShadowBoundaryPoint(elements, atGreatestEclipse, q, false);
+            const fundamental = penumbraBoundaryFundamental(elements, atGreatestEclipse, q);
+            if (point === null || fundamental === null) {
+                continue;
+            }
+            const expected = fundamentalToLatLon(elements, atGreatestEclipse, fundamental.xi, fundamental.eta);
+            if (expected === null) {
+                continue;
+            }
+            expect(point.lat).toBeCloseTo(expected.lat, 6);
+            expect(point.lon).toBeCloseTo(expected.lon, 6);
+            checked++;
+        }
+        expect(checked).toBeGreaterThan(0);
+    });
+
+    it('returns null where the shadow boundary lies off the Earth', () => {
+        for (let q = 0; q < 2 * Math.PI; q += Math.PI / 3) {
+            expect(calculateShadowBoundaryPoint(elements, offEarth, q, false)).toBeNull();
+        }
+    });
+
+    it('traces a small footprint for the umbra around the central line', () => {
+        const points: Array<{lat: number; lon: number}> = [];
+        for (let q = 0; q < 2 * Math.PI; q += Math.PI / 8) {
+            const point = calculateShadowBoundaryPoint(elements, atGreatestEclipse, q, true);
+            if (point !== null) {
+                points.push(point);
+            }
+        }
+
+        expect(points.length).toBeGreaterThan(4);
+        const lats = points.map((p) => p.lat);
+        const lons = points.map((p) => p.lon);
+        expect(Math.max(...lats) - Math.min(...lats)).toBeLessThan(3);
+        expect(Math.max(...lons) - Math.min(...lons)).toBeLessThan(3);
+    });
+});

--- a/packages/solarEclipse/services/shadowGeometry/utils/shadowBoundary.ts
+++ b/packages/solarEclipse/services/shadowGeometry/utils/shadowBoundary.ts
@@ -1,0 +1,84 @@
+import type {LatLon} from '@app/types/LocationTypes';
+import type {BesselianElements, BesselianElementsAtTime} from '@package/solarEclipse/types/BesselianElementTypes';
+import {E_SQ, ONE_MINUS_F} from './constants';
+import {fundamentalToLatLon, solveSurfacePoint} from './surface';
+
+export function calculateShadowBoundaryPoint(
+    elements: BesselianElements,
+    e: BesselianElementsAtTime,
+    q: number,
+    useUmbra: boolean,
+): LatLon | null {
+    const l0 = useUmbra ? e.l2 : e.l1;
+    const tanF = useUmbra ? elements.tanF2 : elements.tanF1;
+    const sinQ = Math.sin(q);
+    const cosQ = Math.cos(q);
+
+    let radius = Math.abs(l0);
+    let result: LatLon | null = null;
+
+    for (let iter = 0; iter < 6; iter++) {
+        const xi = e.x + radius * cosQ;
+        const eta = e.y + radius * sinQ;
+
+        const rho1 = Math.sqrt(1 - E_SQ * e.cosD * e.cosD);
+        const eta1 = eta / rho1;
+        const bSq = 1 - xi * xi - eta1 * eta1;
+        if (bSq < 0) {
+            return null;
+        }
+        const B = Math.sqrt(bSq);
+        const sinD1 = e.sinD / rho1;
+        const cosD1 = (ONE_MINUS_F * e.cosD) / rho1;
+        const sinU = eta1 * cosD1 + B * sinD1;
+
+        const zetaSq = 1 - E_SQ * sinU * sinU - xi * xi - eta * eta;
+        if (zetaSq < 0) {
+            return null;
+        }
+        const zeta = Math.sqrt(zetaSq);
+
+        const newRadius = Math.abs(l0 - zeta * tanF);
+        if (Math.abs(newRadius - radius) < 1e-8) {
+            result = fundamentalToLatLon(elements, e, xi, eta);
+            break;
+        }
+        radius = newRadius;
+    }
+
+    if (result === null) {
+        const xi = e.x + radius * cosQ;
+        const eta = e.y + radius * sinQ;
+        result = fundamentalToLatLon(elements, e, xi, eta);
+    }
+
+    return result;
+}
+
+export function penumbraBoundaryFundamental(
+    elements: BesselianElements,
+    e: BesselianElementsAtTime,
+    q: number,
+): {xi: number; eta: number} | null {
+    const l0 = e.l1;
+    const tanF = elements.tanF1;
+    const sinQ = Math.sin(q);
+    const cosQ = Math.cos(q);
+
+    let radius = Math.abs(l0);
+    for (let iter = 0; iter < 6; iter++) {
+        const xi = e.x + radius * cosQ;
+        const eta = e.y + radius * sinQ;
+        const solution = solveSurfacePoint(elements, e, xi, eta, false);
+        if (solution === null) {
+            return null;
+        }
+        const newRadius = Math.abs(l0 - solution.zeta * tanF);
+        if (Math.abs(newRadius - radius) < 1e-8) {
+            return {xi, eta};
+        }
+        radius = newRadius;
+    }
+
+    return {xi: e.x + radius * cosQ, eta: e.y + radius * sinQ};
+}


### PR DESCRIPTION
Implement SolarEclipse.getSunriseBoundaryPolygon and getSunsetBoundaryPolygon. The rise/set boundary computation is ported into the shadowGeometry service (alongside the umbra/penumbra polygons) using the modelled deltaT via getEclipseDeltaT, consistent with the rest of the migrated shadow-path geometry.